### PR TITLE
fix typo, clarify root-prim wording, correct relationships bullet

### DIFF
--- a/docs/source/stage-setting/prims.md
+++ b/docs/source/stage-setting/prims.md
@@ -137,7 +137,7 @@ stage.Save()
 DisplayUSD(file_path, show_usd_code=True)
 ```
 
-In this example, we used the `UsdGeom.Sphere` class to create a Sphere type prim and set some data about that sphere. We set there sphere's `radius` to `5`. Using the `UsdGeom.Sphere` class provides a more transparent interface for the Sphere prim type.
+In this example, we used the `UsdGeom.Sphere` class to create a Sphere type prim and set some data about that sphere. We set there sphere's `radius` to `2`. Using the `UsdGeom.Sphere` class provides a more transparent interface for the Sphere prim type.
 
 ### Example 3: Creating a Prim Hierarchy
 
@@ -171,7 +171,7 @@ The prim hierarchy that we have created is:
     - *GroupTransform*
         - *Cube*
 
-By nesting prims in this way, a hierarchical scenegraph begins to take shape. In this example, "Geometry" is the root prim. We are also defining three different types of prims here: [`Scope`](https://openusd.org/release/api/class_usd_geom_scope.html), [`Xform`](https://openusd.org/release/api/class_usd_geom_xform.html), and [`Cube`](https://openusd.org/release/api/class_usd_geom_cube.html). We will look at these prim types more closely in other lessons, but for a brief description:
+By nesting prims in this way, a hierarchical scenegraph begins to take shape. In this example, "Geometry" is the root prim. In other words, "Geometry" is a direct child of the pseudo-root `/`. We are also defining three different types of prims here: [`Scope`](https://openusd.org/release/api/class_usd_geom_scope.html), [`Xform`](https://openusd.org/release/api/class_usd_geom_xform.html), and [`Cube`](https://openusd.org/release/api/class_usd_geom_cube.html). We will look at these prim types more closely in other lessons, but for a brief description:
 
 - **Xform**: Defines a transform (translate, rotation, scale)
 - **Scope**: Is a simple container that does not hold transform data

--- a/docs/source/stage-setting/properties/relationships.md
+++ b/docs/source/stage-setting/properties/relationships.md
@@ -71,7 +71,7 @@ Relationships enable robust encoding of dependencies and associations between sc
 * Binding geometry to materials
 * Grouping prims into collections
 * Establishing connections in shading networks
-* Modeling hierarchical relationships (e.g. parent-child)
+* Associating scene elements with non-hierarchical links (e.g. material binding)
 
 Using relationships instead of hard paths enhances:
 


### PR DESCRIPTION
This PR includes three documentation fixes in the Prims and Relationships lessons:

- **Fixes typos**: “there sphere’s `radius`” $\rightarrow$ “**the** sphere’s `radius`”, and aligns the text with the code (radius is set to `2`).
- **Clarifies “root prim” wording** to reflect accurate USD terminology, explaining that a root prim is a **direct child** of the pseudo-root `/`, and avoids confusion with `defaultPrim`.
- **Corrects Relationships key takeaway**: replaces the potentially misleading bullet *“Modeling hierarchical relationships (e.g. parent-child)”* with *“Associating scene elements with non-hierarchical links (e.g., material binding or collections)”*, since hierarchy in USD is defined by prim paths, not `UsdRelationship`.

**References**
- Fixes #1  (the typo)

**Rationale**

Fixes typos and improves clarity in both the Prims and Relationships lessons.