### PR TITLE
Remove Variant Sets lesson in Composition Basics

### DIFF
--- a/docs/composition-basics/index.md
+++ b/docs/composition-basics/index.md
@@ -36,5 +36,4 @@ strength-ordering
 specifiers
 references
 default-prim
-variant-sets
 :::


### PR DESCRIPTION
The Variant Sets lesson wasn't supposed to be included in the TOC. There is some good content in that lesson, but it needs to be presented more simply and from more of end-user perspective.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the variant-sets section from the Composition Basics documentation table of contents, streamlining the navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->