### PR TITLE
Setting the Stage Edits

### DIFF
--- a/docs/stage-setting/prim-property-paths.md
+++ b/docs/stage-setting/prim-property-paths.md
@@ -124,31 +124,36 @@ DisplayCode("_assets/paths.usda")
 ```
 
 ### Example 2: Build and navigate prim paths with Sdf.Path
-Construct prim paths with AppendChild and AppendPath, then validate and navigate them with IsPrimPath and GetParentPath
+Construct prim paths with AppendChild, then validate and navigate them with IsPrimPath and GetParentPath
 
 ```{code-cell}
-:emphasize-lines: 5-21
+:emphasize-lines: 5-26
 from pxr import Usd, UsdGeom, Sdf
 
 stage = Usd.Stage.CreateNew("_assets/paths_build_and_nav.usda")
 
 # Build prim paths via Sdf.Path
 world_path = Sdf.Path("/World")
-geometry_path = world_path.AppendChild("Geometry") # /World/Geometry
-sphere_path = geometry_path.AppendChild("Sphere") # /World/Geometry/Sphere
-looks_path = world_path.AppendPath("Looks/Material") # /World/Looks/Material
+geometry_path = world_path.AppendChild("Geometry")  # /World/Geometry
+sphere_path = geometry_path.AppendChild("Sphere")  # /World/Geometry/Sphere
+
+looks_path = world_path.AppendChild("Looks")  # /World/Looks
+material_path = looks_path.AppendChild("Material")  # /World/Looks/Material
 
 # Define prims at those paths
 stage.DefinePrim(world_path)
 stage.DefinePrim(geometry_path)
 UsdGeom.Sphere.Define(stage, sphere_path)
 stage.DefinePrim(looks_path)
+stage.DefinePrim(material_path)
 
 # Path checks and basic navigation
 print("sphere_path IsPrimPath:", sphere_path.IsPrimPath())
 print("sphere_path parent:",    sphere_path.GetParentPath())
 print("Geometry prim valid:",   stage.GetPrimAtPath(geometry_path).IsValid())
-print("Material prim valid:",   stage.GetPrimAtPath(looks_path).IsValid())
+print("\nmaterial_path IsPrimPath:", material_path.IsPrimPath())
+print("material_path parent:",    material_path.GetParentPath())
+print("Looks prim valid:",   stage.GetPrimAtPath(looks_path).IsValid())
 
 stage.Save()
 
@@ -162,7 +167,7 @@ DisplayCode("_assets/paths_build_and_nav.usda")
 A property path identifies a property location but does not create anything by itself. You use AppendProperty to build the path, then author the spec with CreateAttribute or CreateRelationship
 
 ```{code-cell}
-:emphasize-lines: 8-37
+:emphasize-lines: 8-38
 
 from pxr import Usd, UsdGeom, Sdf
 
@@ -170,12 +175,13 @@ stage = Usd.Stage.CreateNew("_assets/paths_property_authoring.usda")
 
 # A prim to work with
 sphere = UsdGeom.Sphere.Define(stage, "/World/Geom/Sphere")
-# Create a property path for the attribute /World/Geom/Sphere.user:tag
-attr_property_path = sphere.GetPath().AppendProperty("user:tag")
+
+# Create a property path for the attribute /World/Geom/Sphere.userProperties:tag
+attr_property_path = sphere.GetPath().AppendProperty("userProperties:tag")
 
 # Working with the property path for the attribute
 owner_prim = stage.GetPrimAtPath(attr_property_path.GetPrimPath())
-attr_name = stage.GetPropertyAtPath(attr_property_path).GetPath().name  # "user:tag"
+attr_name = stage.GetPropertyAtPath(attr_property_path).GetPath().name  # "userProperties:tag"
 print(f"Attribute property '{attr_name}' has been defined on {owner_prim.GetPath()} after AppendProperty: {owner_prim.GetAttribute(attr_name).IsDefined()}")
 
 # Define the attribute on the owner prim

--- a/docs/stage-setting/timecodes-timesamples.md
+++ b/docs/stage-setting/timecodes-timesamples.md
@@ -142,7 +142,7 @@ To set the stage's `start` TimeCode and `end` TimeCode metadata, use the [`SetSt
 
 ```{code-cell}
 :tags: [remove-output]
-:emphasize-lines: 12-14
+:emphasize-lines: 6-8
 
 from pxr import Usd
 
@@ -190,7 +190,7 @@ Let's create a sphere that moves up and down using the [`XformCommonAPI`](https:
 
 ```{code-cell}
 :tags: [remove-output]
-:emphasize-lines: 19-31
+:emphasize-lines: 8-24
 
 from pxr import Usd, UsdGeom, Gf
 
@@ -199,7 +199,7 @@ stage: Usd.Stage = Usd.Stage.Open("_assets/timecode_ex1.usda")
 
 sphere: UsdGeom.Sphere = UsdGeom.Sphere.Get(stage, "/World/Sphere")
 
-# Grab the translate 
+# Clear any existing translation
 if translate_attr := sphere.GetTranslateOp().GetAttr():
     translate_attr.Clear()
 
@@ -235,7 +235,7 @@ It is possible to set timeSamples for different attributes. We can demonstrate t
 
 ```{code-cell}
 :tags: [remove-output]
-:emphasize-lines: 28-37
+:emphasize-lines: 8-22
 
 from pxr import Usd, UsdGeom, Gf
 

--- a/docs/stage-setting/usd-file-formats.md
+++ b/docs/stage-setting/usd-file-formats.md
@@ -34,7 +34,7 @@ In these lessons, we primarily use USDA files because they are human-readable, m
 
 ```{note}
 The file formats used in these lessons are chosen for clarity. In production, follow the OpenUSD guidance for production use cases, which includes:
-* Prefer the binary usdc format (often saved with the .usd extension) for layers that contain real content such as geometry or shading, because it opens faster and uses less memory.
+* Prefer the binary usdc format (often saved with the .usd extension) for layers that contain data-heavy content such as geometry or shading networks, because it opens faster and uses less memory.
 * Reserve usda text for small, human‑readable “interface” layers that mostly reference or sublayer other files, and for debugging or diffing.
 * In general, “prefer crate files” for big data, and keep text to lightweight aggregators.
 


### PR DESCRIPTION
PR Brings:
- Fix import issues with Gf in example code for `timecodes-timesamples`
- Use standard stage.CreateNew() instead of helper function in `timecodes-timesamples`
- Modify examples in `timecodes-timesamples` to build on previous files via `Usd.Stage.Open` rather than redefine all content each time.
- Add additional examples for `prim-property-paths`
- Add additional context to note about production use for `usd-file-formats`