### PR TITLE
Handle dark theme home header (#26)

### DIFF
--- a/docs/_static/css/lousd_custom.css
+++ b/docs/_static/css/lousd_custom.css
@@ -71,3 +71,9 @@ table.venv-setup .highlight-shell, .table.venv-setup .highlight-powershell {
     padding-right: 50%;
     color: black;
 }
+
+/* Swap hero image/text when the theme toggle sets data-theme="dark" */
+html[data-theme="dark"] .home-header > h1 {
+    background-image: url(../learn-openusd-bbm-dark.jpg);
+    color: white;
+}

--- a/docs/_static/learn-openusd-bbm-dark.jpg
+++ b/docs/_static/learn-openusd-bbm-dark.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1964349ba5b2aa96093f468905dfc8c70c214eb84494ed57ff0380c37af2b7d5
+size 199071


### PR DESCRIPTION
Fixes #26

- add dark home header image
- add dark-theme override for header image/title color
- keep light theme default unchanged

Tests: make html
