### PR TITLE
Fix predicates docs (Fix #44)

### DIFF
--- a/docs/beyond-basics/stage-traversal.md
+++ b/docs/beyond-basics/stage-traversal.md
@@ -90,7 +90,7 @@ for prim in it:
         prim_range.PruneChildren()  # Skip all children of "Environment"
 ```
 
-````{warning}
+````{caution}
 Boolean operators, like `and`/`or`/`not`, will NOT combine predicates as intended.  
 Always combine traversal predicates with bitwise operators (`&`, `|`, `~`).  
 For example, AVOID the following:


### PR DESCRIPTION
Fixes #44 

Fixed typo on line 80: used -> using

Added lines to clearly state NOT to use boolean operators to combine preicates (kept the `bad_predicate` definition commented to stress it's not to be used)