### PR TITLE
Added SetRotate for rotating cones.

### DIFF
--- a/docs/beyond-basics/model-kinds.md
+++ b/docs/beyond-basics/model-kinds.md
@@ -152,7 +152,7 @@ points = {
     }
 for name, pos in points.items():
     cone = UsdGeom.Cone.Define(stage, markers.GetPath().AppendChild(name))
-	cone.CreateAxisAttr(UsdGeom.Tokens.y)
+    cone.CreateAxisAttr(UsdGeom.Tokens.y)
     UsdGeom.XformCommonAPI(cone).SetTranslate(pos)
     cone.CreateDisplayColorPrimvar().Set([Gf.Vec3f(1.0, 0.85, 0.2)])
 


### PR DESCRIPTION
Issue:
Example 1 in Beyond Basics - Model Kinds subsection does not create cone prims in the correct orientation:
<img width="520" height="355" alt="image" src="https://github.com/user-attachments/assets/4c4fc087-e50a-4e69-b461-e0b4cace4606" />
After Fix:
<img width="516" height="339" alt="image" src="https://github.com/user-attachments/assets/df3d0178-025a-4699-8883-378b0f0a3662" />

