### PR TITLE
Convert absolute external links to cross-project references #7

### DIFF
--- a/docs/beyond-basics/stage-traversal.md
+++ b/docs/beyond-basics/stage-traversal.md
@@ -149,7 +149,7 @@ DisplayCode(file_path)
 
 ### Example 1: Traversing Through the Stage
 
-To traverse through the stage, we can use the [`Traverse()`](https://openusd.org/release/api/class_usd_stage.html#adba675b55f41cc1b305bed414fc4f178) method. This traversal will yield prims that are active, loaded, defined, non-abstract on the stage in depth-first order.
+To traverse through the stage, we can use the {usdcpp}`UsdStage::Traverse` method. This traversal will yield prims that are active, loaded, defined, non-abstract on the stage in depth-first order.
 
 ```{code-cell}
 :test-tags: [stage-traversal-traverse]
@@ -173,7 +173,7 @@ Note how the prims were printed in depth-first order. All of the descendants of 
 
 For this practical example, we will traverse the stage to operate on specific prims based on their types.
 
-We can filter based on the type of the prim. For example, we can check if the prim is of type `scope` or `xform`. To do this we pass the prim into the constructor method for the prim type we are interested in. For example,`UsdGeom.Scope(prim)` is equivalent to [`UsdGeom.Scope.Get(prim.GetStage(), prim.GetPath())`](https://openusd.org/release/api/class_usd_geom_scope.html#a538339c2aa462ebcf1eb07fed16f9be4) for a valid prim. If the prim's type does not match, it will return an invalid prim.
+We can filter based on the type of the prim. For example, we can check if the prim is of type `scope` or `xform`. To do this we pass the prim into the constructor method for the prim type we are interested in. For example,`UsdGeom.Scope(prim)` is equivalent to {usdcpp}`UsdGeomScope::Get` for a valid prim. If the prim's type does not match, it will return an invalid prim.
 
 ```{code-cell}
 :test-tags: [stage-traversal-filter-types]
@@ -204,7 +204,7 @@ print("Number of Xform prims: ", xform_count)
 
 ### Example 3: Traversing Through the Children of a Prim
 
-Using [`Traverse()`](https://openusd.org/release/api/class_usd_stage.html#adba675b55f41cc1b305bed414fc4f178) can be a powerful tool, but for large stages, more efficient and targeted methods should be considered. A way to be more efficient and targeted is to traverse through the children of a prim.
+Using {usdcpp}`UsdStage::Traverse` can be a powerful tool, but for large stages, more efficient and targeted methods should be considered. A way to be more efficient and targeted is to traverse through the children of a prim.
 
 If you need to work within a specific scope or hierarchy in the stage, you can perform a traversal starting from a particular prim. Let's take a look at how we can traverse through the children of the default prim.
 
@@ -230,9 +230,9 @@ for child in default_prim.GetAllChildren():
 
 ### Example 4: Traversing Using Usd.PrimRange
 
-[`Traverse()`](https://openusd.org/release/api/class_usd_stage.html#adba675b55f41cc1b305bed414fc4f178) will return a [`UsdPrimRange`](https://openusd.org/release/api/class_usd_prim_range.html) object. `UsdPrimRange` exposes pre- and post- prim visitations allowing for a more involved traversals. It can also be used to perform actions such as pruning subtrees.
+{usdcpp}`UsdStage::Traverse` will return a {usdcpp}`UsdPrimRange` object. `UsdPrimRange` exposes pre- and post- prim visitations allowing for a more involved traversals. It can also be used to perform actions such as pruning subtrees.
 
-Let's see an example of [`UsdPrimRange`](https://openusd.org/release/api/class_usd_prim_range.html) in use.
+Let's see an example of {usdcpp}`UsdPrimRange` in use.
 
 
 ```{code-cell}
@@ -252,7 +252,7 @@ for prim in prim_range:
 
 Note how only "/World/Box" and its descendants are printed.
 
-There are other ways to use [`UsdPrimRange`](https://openusd.org/release/api/class_usd_prim_range.html) such as passing in [`predicates`](https://openusd.org/release/api/prim_flags_8h.html#Usd_PrimFlags), you can find more information in the [Using Usd.PrimRange in Python](https://openusd.org/release/api/class_usd_prim_range.html#details) section of `UsdPrimRange`.
+There are other ways to use {usdcpp}`UsdPrimRange` such as passing in predicates, you can find more information in the {usdcpp}`UsdPrimRange Details` section of `UsdPrimRange`.
 
 
 ## Key Takeaways

--- a/docs/composition-basics/default-prim.md
+++ b/docs/composition-basics/default-prim.md
@@ -109,7 +109,7 @@ from lousd.utils.helperfunctions import create_new_stage
 
 ### Example 1: Setting a Default Prim
 
-[`SetDefaultPrim()`](https://openusd.org/release/api/class_usd_stage.html#a82b260faf91fbf721b0503075f2861e2) sets the default prim for the stage's root layer.
+{usdcpp}`UsdStage::SetDefaultPrim` sets the default prim for the stage's root layer.
 
 A `defaultPrim` is layer metadata. If the stage's root layer is used as a reference or payload it is best practice to set a default prim.
 

--- a/docs/composition-basics/references.md
+++ b/docs/composition-basics/references.md
@@ -95,9 +95,9 @@ def Xform "World"
 }
 ```
 
-Firstly, we want to grab all references of a prim. To do this we use [`GetReferences()`](https://openusd.org/release/api/class_usd_prim.html#ac9081d27e9d2a1058e32249fb96aaa34). This returns a [`UsdReferences`](https://openusd.org/release/api/class_usd_references.html) object, which allows us to add, remove, and modify references.
+Firstly, we want to grab all references of a prim. To do this we use {usdcpp}`UsdPrim::GetReferences`. This returns a {usdcpp}`UsdReferences` object, which allows us to add, remove, and modify references.
 
-To add a reference, we use [`AddReference()`](https://openusd.org/release/api/class_usd_references.html#a95bf456b23a234d3aa017015a4ad05e0). Let's see these in practice.
+To add a reference, we use {usdcpp}`UsdReferences::AddReference`. Let's see these in practice.
 
 ```{code-cell}
 :test-tags: [references-add-reference]

--- a/docs/creating-composition-arcs/prim-composition.md
+++ b/docs/creating-composition-arcs/prim-composition.md
@@ -28,7 +28,7 @@ Those are combined during {term}`composition <Composition>`.
 
 Knowing that properties can be {term}`attributes <Attribute>` or {term}`relationships <Relationship>`, when talking about property specs you can infer that there are attribute specs and relationship specs.
 
-You can interact with Specs using the [Sdf (Scene Description Foundations) API](https://openusd.org/release/api/class_sdf_spec.html). Both prim spec and property spec have their own API that is based off of `SdfSpec` API.
+You can interact with Specs using the {usdcpp}`SdfSpec` API. Both prim spec and property spec have their own API that is based off of `SdfSpec` API.
 
 The image above shows the different parts of the composition. Here we have the rendered result on the left and the USDA file represented on the right. Sphere is  a prim spec, `radius` is a property spec, and the value to the right of `radius` is an opinion.
 

--- a/docs/creating-composition-arcs/references-payloads/references-faq.md
+++ b/docs/creating-composition-arcs/references-payloads/references-faq.md
@@ -4,7 +4,7 @@ Let’s take some time to ask some common questions when it comes to working wit
 
 ## Why not add these as sublayers? Why add them as references?
 
-This depends on two things, the contents of the {term}`layers <Layer>` and what you will need to do with the resulting {term}`composition <Composition>`. Since we are adding `skyscraperA` twice, if added as a {term}`sublayer <Sublayer>` then the first sublayer would overwrite the second `skyscraperA` instead of adding a second skyscraper. For more information on when to use sublayers vs references visit this site: [USD Frequently Asked Questions](https://openusd.org/release/usdfaq.html#i-have-some-layers-i-want-to-combine-should-i-use-sublayers-or-references)
+This depends on two things, the contents of the {term}`layers <Layer>` and what you will need to do with the resulting {term}`composition <Composition>`. Since we are adding `skyscraperA` twice, if added as a {term}`sublayer <Sublayer>` then the first sublayer would overwrite the second `skyscraperA` instead of adding a second skyscraper. For more information on when to use sublayers vs references visit this site: [USD Frequently Asked Questions](inv:usd:std:doc#usdfaq)
 
 Sublayers are like including, but referencing is like grafting.
 
@@ -12,4 +12,4 @@ Sublayers are like including, but referencing is like grafting.
 
 You may have noticed the prepend operation in the reference statement above. Prepend means that, when this layer is composed with others to populate the {term}`stage <Stage>`, the reference will be inserted before any references that might exist in weaker sublayers. This ensures that the contents of the reference will contribute stronger {term}`opinions <Opinions>` than any reference arcs that might exist in other, weaker layers.
 
-In other words, prepend gives the intuitive result you’d expect when you apply one layer on top of another. This is what the [UsdReferences](https://openusd.org/release/api/class_usd_references.html) API will create by default. You can specify other options with the position parameter, but this should rarely be necessary.
+In other words, prepend gives the intuitive result you’d expect when you apply one layer on top of another. This is what the {usdcpp}`UsdReferences` API will create by default. You can specify other options with the position parameter, but this should rarely be necessary.

--- a/docs/creating-composition-arcs/sublayers/working-with-sublayers.md
+++ b/docs/creating-composition-arcs/sublayers/working-with-sublayers.md
@@ -60,7 +60,7 @@ You can find these files in the `composition_arcs/sublayers/exercise/contents/` 
 
 5. To start, go to `composition_arcs/sublayers/exercise/sublayers_exercise.py` from Visual Studio Code’s explorer window.
 
-We will be adding in code that adds sublayers to our root layer. This is done using [Sdf.Layer API](https://openusd.org/release/api/class_sdf_layer.html).
+We will be adding in code that adds sublayers to our root layer. This is done using {usdcpp}`SdfLayer` API.
 
 ![](../../images/composition-arcs/image94.png)
 

--- a/docs/data-exchange/data-exchange/what-is-data-exchange.md
+++ b/docs/data-exchange/data-exchange/what-is-data-exchange.md
@@ -70,7 +70,7 @@ File format plugins are a unique feature of OpenUSD. They allow OpenUSD to compo
 - An OpenUSD {term}`stage <Stage>` can include a source file format directly as a {term}`reference <Reference>`, {term}`payload <Payload>` or {term}`sublayer <Sublayer>`. The source file format is translated on the fly, while it is read as a USD document ({term}`layer <Layer>`, in USD parlance).
 - The source file format can remain the source of truth.
 - File format plugins can be bidirectional, supporting both reading from and writing to the source file format.
-- They can be used as standalone converters with tools like [usdcat](https://openusd.org/release/toolset.html#usdcat).
+- They can be used as standalone converters with tools like [usdcat](inv:usd:std#toolset:usdcat).
 
 ![](../../images/data-exchange/image1.png)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,7 +57,7 @@ Asset Info
     database name), payloadAssetDependencies (pre-computed dependencies for optimization), and version (asset revision information). Asset info persists through composition and flattening, enabling you to track where assets are introduced in your scene and reconstruct references to them.
 
     **Also Known As:** *AssetInfo, asset metadata*  
-    **Further Reading**: [AssetInfo -- OpenUSD.org](<inv:usd:std#glossary:assetinfo>), [UsdObject AssetInfo API](<https://openusd.org/release/api/class_usd_object.html>)
+    **Further Reading**: [AssetInfo -- OpenUSD.org](<inv:usd:std#glossary:assetinfo>), {usdcpp}`UsdObject`
 
 Asset Resolution
 
@@ -65,7 +65,7 @@ Asset Resolution
 
     USD provides a plugin point called `ArResolver` that you can customize to resolve assets using your own logic, external databases, or version control systems. If no custom resolver is available, USD uses a default resolver that searches for assets using configurable search paths.
 
-    **Further Reading**: [Asset Resolution -- OpenUSD.org](<inv:usd:std#glossary:asset resolution>), [ArResolver Documentation](<https://openusd.org/release/api/ar_page_front.html>)
+    **Further Reading**: [Asset Resolution -- OpenUSD.org](<inv:usd:std#glossary:asset resolution>), {usdcpp}`ArResolver <ar_page_front>`
 
 Attribute
 
@@ -90,7 +90,7 @@ Change Processing
 
     When you edit a layer, the stage immediately re-indexes affected prims in the same thread, potentially adding, removing, or modifying prims to maintain an accurate composed view. After processing changes, the stage notifies registered clients through the notification system so they can update themselves accordingly.
 
-     **Further Reading**: [Change Processing -- OpenUSD.org](<inv:usd:std#glossary:change processing>), [UsdNotice](<https://openusd.org/release/api/class_usd_notice.html>)
+     **Further Reading**: [Change Processing -- OpenUSD.org](<inv:usd:std#glossary:change processing>), {usdcpp}`UsdNotice`
 
 Class
 
@@ -109,7 +109,7 @@ Collection
     Collections use include and exclude relationships with expansion rules to compactly represent large object sets, implemented through the multiple-apply `UsdCollectionAPI` schema. They support explicit path lists and pattern-based membership, and can include prims, properties, or even other collections.
 
     **Also Known As:** *UsdCollectionAPI*  
-    **Further Reading**: [Collections and Patterns](<https://openusd.org/release/user_guides/collections_and_patterns.html>), [Collection -- OpenUSD.org](<inv:usd:std#glossary:collection>)
+    **Further Reading**: [Collections and Patterns](<inv:usd:std:doc#user_guides/collections_and_patterns>), [Collection -- OpenUSD.org](<inv:usd:std#glossary:collection>)
 
 Component
 
@@ -197,7 +197,7 @@ Flatten
 
     Flattening converts a dynamically composed stage into a single standalone layer by resolving all composition arcs and baking the results, creating a highly portable file that contains everything. The trade-off is larger file size since referenced assets get duplicated, and the process can be memory and compute intensive. You can flatten using `UsdStage::Flatten` or the usdcat tool with `--flatten`.
 
-    **Further Reading**: [Flatten -- OpenUSD.org](<inv:usd:std#glossary:flatten>), [usdcat Tool](<https://openusd.org/release/toolset.html#usdcat>)
+    **Further Reading**: [Flatten -- OpenUSD.org](<inv:usd:std#glossary:flatten>), [usdcat Tool](<inv:usd:std#toolset:usdcat>)
 
 Gprim
 
@@ -438,7 +438,7 @@ Prim Definition
     The prim definition combines a prim's IsA schema and applied API schemas to determine its built-in properties and metadata beyond its authored scene description. It also provides fallback values for these built-in elements during value resolution, accessible through the `UsdPrimDefinition` class.
 
     **Also Known As:** *type definition, schema definition*  
-    **Further Reading**: [Prim Definition -- OpenUSD.org](<inv:usd:std#glossary:prim definition>), [UsdPrimDefinition API](<https://openusd.org/release/api/class_usd_prim_definition.html>)
+    **Further Reading**: [Prim Definition -- OpenUSD.org](<inv:usd:std#glossary:prim definition>), {usdcpp}`UsdPrimDefinition`
 
 Prim Spec
 
@@ -518,7 +518,7 @@ Purpose
 
     Purpose is a UsdGeomImageable attribute that provides visibility categories that gate scenegraph traversals, with values including "default" (general geometry), "render" (final quality), "proxy" (lightweight preview), and "guide" (visualization helpers). This allows clients to independently include or exclude geometry categories during traversals like rendering or bounding box computation. Purpose is inherited down the namespace hierarchy until explicitly overridden.
 
-    **Further Reading**: [Purpose -- OpenUSD.org](<inv:usd:std#glossary:purpose>), [UsdGeomImageable](<https://openusd.org/release/api/class_usd_geom_imageable.html>)
+    **Further Reading**: [Purpose -- OpenUSD.org](<inv:usd:std#glossary:purpose>), {usdcpp}`UsdGeomImageable`
 
 Reference
 
@@ -571,7 +571,7 @@ Session Layer
 
     Created optionally with a stage, the session layer is the strongest layer in the stage's root layer stack and can have its own sublayers. Session layers embody application state rather than asset data, and commonly contain UI-driven selections like variant choices, visibility overrides, and activation state. `UsdStage::Save()` does not save the session layer, as it's considered temporary application state rather than permanent scene data.
 
-    **Further Reading**: [Session Layer -- OpenUSD.org](<inv:usd:std#glossary:session layer>), [usdview](<https://openusd.org/release/toolset.html#usdview>)
+    **Further Reading**: [Session Layer -- OpenUSD.org](<inv:usd:std#glossary:session layer>), [usdview](<inv:usd:std#toolset:usdview>)
 
 Specialize
 
@@ -691,7 +691,7 @@ Visibility
     Managed by the `UsdGeomImageable` schema, visibility is inherited down the prim hierarchy and can be set to "inherited" (use parent's visibility) or "invisible" (hide this prim and descendants). Unlike active/inactive which affects composition, visibility is purely a rendering concept. Computing visibility requires traversing ancestor prims, so USD provides the efficient `UsdGeomImageable::ComputeVisibility()` method rather than simple attribute queries.
 
     **Also Known As:** *prim visibility*  
-    **Further Reading**: [Visibility -- OpenUSD.org](<inv:usd:std#glossary:visibility>), [UsdGeomImageable](<https://openusd.org/release/api/class_usd_geom_imageable.html>)
+    **Further Reading**: [Visibility -- OpenUSD.org](<inv:usd:std#glossary:visibility>), {usdcpp}`UsdGeomImageable`
 
 :::
 

--- a/docs/scene-description-blueprints/lights.md
+++ b/docs/scene-description-blueprints/lights.md
@@ -86,7 +86,7 @@ from lousd.utils.helperfunctions import create_new_stage
 
 [`UsdLux`](https://openusd.org/release/api/usd_lux_page_front.html) is a USD lighting schema that provides a representation for lights.
 
-One of the schemas in `UsdLux` is [`DistantLight`](https://openusd.org/release/api/class_usd_lux_distant_light.html). A light is emitted from a distance source along the -Z axis. This is commonly known as a directional light.
+One of the schemas in `UsdLux` is {usdcpp}`UsdLuxDistantLight`. A light is emitted from a distance source along the -Z axis. This is commonly known as a directional light.
 
 ```{code-cell}
 :test-tags: [lights-distant-light]
@@ -119,7 +119,7 @@ DisplayUSD(file_path, show_usd_code=True)
 
 ### Example 2: Setting Light Properties
 
-We're going to define two new prims, [`SphereLight`](https://openusd.org/dev/api/class_usd_lux_sphere_light.html) and [`DistantLight`](https://openusd.org/release/api/class_usd_lux_distant_light.html), and set a few properties for them.
+We're going to define two new prims, {usdcpp}`UsdLuxSphereLight` and {usdcpp}`UsdLuxDistantLight`, and set a few properties for them.
 
 
 ```{code-cell}

--- a/docs/scene-description-blueprints/materials-shaders.md
+++ b/docs/scene-description-blueprints/materials-shaders.md
@@ -54,7 +54,7 @@ from lousd.utils.helperfunctions import create_new_stage
 
 [`UsdShade`](https://openusd.org/release/api/usd_shade_page_front.html) is a {term}`schema <Schema>` for creating and binding materials.
 
-[`Material`](https://openusd.org/release/api/class_usd_shade_material.html) provides a container to store data for defining a "shading material" to a renderer.
+{usdcpp}`UsdShadeMaterial` provides a container to store data for defining a "shading material" to a renderer.
 
 `UsdShade` and `Materials` will be covered in later topics and are only covered here to show another use case for schema-specific APIs.
 

--- a/docs/scene-description-blueprints/scope.md
+++ b/docs/scene-description-blueprints/scope.md
@@ -69,9 +69,9 @@ from lousd.utils.helperfunctions import create_new_stage
 ```
 
 ### Example 1: Define a Scope
-[`Scope`](https://openusd.org/release/api/class_usd_geom_scope.html) is a grouping primitive and does NOT have transformability. It can be used to organize libraries with large numbers of entry points. It also is best to group actors and environments under partitioning Scopes. Besides navigating, it's easy for a user to {term}`deactivate <Active and Inactive>` all actors or environments by deactivating the root scope.
+{usdcpp}`UsdGeomScope` is a grouping primitive and does NOT have transformability. It can be used to organize libraries with large numbers of entry points. It also is best to group actors and environments under partitioning Scopes. Besides navigating, it's easy for a user to {term}`deactivate <Active and Inactive>` all actors or environments by deactivating the root scope.
 
-We can define `Scope`using [`UsdGeom.Scope.Define()`](https://openusd.org/release/api/class_usd_geom_scope.html#acdb17fed396719a9a21294ebca0116ae).
+We can define `Scope`using {usdcpp}`UsdGeomScope::Define`.
 
 ```{code-cell}
 :test-tags: [scope-define-scopes]

--- a/docs/scene-description-blueprints/xform.md
+++ b/docs/scene-description-blueprints/xform.md
@@ -76,10 +76,10 @@ from lousd.utils.helperfunctions import create_new_stage
 
 Some things to know about `UsdGeom`:
 
-- All classes in `UsdGeom` inherit from [`UsdGeomImageable`](https://openusd.org/release/api/class_usd_geom_imageable.html), whose intent is to capture any prim type that might want to be rendered or visualized.
-- All geometry prims are directly transformable. [`UsdGeomXformable`](https://openusd.org/release/api/class_usd_geom_xformable.html) encapsulates the schema for a prim that is transformable.  
+- All classes in `UsdGeom` inherit from {usdcpp}`UsdGeomImageable`, whose intent is to capture any prim type that might want to be rendered or visualized.
+- All geometry prims are directly transformable. {usdcpp}`UsdGeomXformable` encapsulates the schema for a prim that is transformable.
 
-[`UsdGeomXform`](https://openusd.org/release/api/class_usd_geom_xform.html) is a concrete prim schema for a transform, which is transformable and can transform other child prims as a group.
+{usdcpp}`UsdGeomXform` is a concrete prim schema for a transform, which is transformable and can transform other child prims as a group.
 
 
 ```{code-cell}

--- a/docs/scene-description-blueprints/xformcommonapi.md
+++ b/docs/scene-description-blueprints/xformcommonapi.md
@@ -64,7 +64,7 @@ xform_api.SetScale((2.0, 2.0, 2.0))
 ```
 
 These functions demonstrate how to apply translations, rotations, and scaling to a 3D object using the `XformCommonAPI`. We can get a transformation matrix
-from the xformable prim that works with any `xformOp` order using the [`GetLocalTransformation`](https://openusd.org/release/api/class_usd_geom_xformable.html#a9a04ccb1ba8aa16e8cc1e878c2c92969) method.
+from the xformable prim that works with any `xformOp` order using the {usdcpp}`UsdGeomXformable::GetLocalTransformation` method.
 
 ## Examples
 
@@ -84,7 +84,7 @@ from lousd.utils.helperfunctions import create_new_stage
 
 ### Example 1: XformCommonAPI - Transforms and Inheritance
 
-In this example, we will use the [`XformCommonAPI`](https://openusd.org/release/api/class_usd_geom_xform_common_a_p_i.html) to translate, rotate, and scale a parent Xform, then show how a child under that parent inherits those transforms while a similar child under a separate {term}`prim hierarchy <Namespace>` does not.
+In this example, we will use the {usdcpp}`UsdGeomXformCommonAPI` to translate, rotate, and scale a parent Xform, then show how a child under that parent inherits those transforms while a similar child under a separate {term}`prim hierarchy <Namespace>` does not.
 
 ```{code-cell}
 :test-tags: [xformcommonapi-transforms-inheritance]

--- a/docs/stage-setting/prim-property-paths.md
+++ b/docs/stage-setting/prim-property-paths.md
@@ -89,9 +89,9 @@ Each prim has a path to describe its location in namespace.
 
 For example, we defined a prim `hello` at path `/hello` and another prim `world` at path `/hello/world`.
 
-We can retrieve prims using their path using [`GetPrimAtPath()`](https://openusd.org/release/api/class_usd_stage.html#a6ceb556070804b712c01a7968f925735). This will either return a valid or invalid prim. When using `GetPrimAtPath()` we should always check if the returned prim is valid before using it.
+We can retrieve prims using their path using {usdcpp}`UsdStage::GetPrimAtPath`. This will either return a valid or invalid prim. When using `GetPrimAtPath()` we should always check if the returned prim is valid before using it.
 
-To check if a prim is valid we can use the [`IsValid()`](https://openusd.org/release/api/class_usd_object.html#ac532c4b500b1a85ea22217f2c65a70ed) method. Valid means that the prim exists in the stage. Invalid is when the prim does not exist in the stage or when the path is invalid.
+To check if a prim is valid we can use the {usdcpp}`UsdObject::IsValid` method. Valid means that the prim exists in the stage. Invalid is when the prim does not exist in the stage or when the path is invalid.
 
 
 ```{code-cell}

--- a/docs/stage-setting/prims.md
+++ b/docs/stage-setting/prims.md
@@ -91,7 +91,7 @@ from lousd.utils.helperfunctions import create_new_stage
 
 A prim is the primary container object in USD. It can contain other prims and properties holding data.
 
-To create a generic prim on the stage we use [`DefinePrim()`](https://openusd.org/release/api/class_usd_stage.html#a6151ae804f7145e451d9aafdde347730). By default, the prim will be typeless meaning that it's just an empty container. By introducing a prim type, we can begin to dictate what kind of data the prim contains depending on if it is a prim to represent a cube, a light, a mesh, etc.
+To create a generic prim on the stage we use {usdcpp}`UsdStage::DefinePrim`. By default, the prim will be typeless meaning that it's just an empty container. By introducing a prim type, we can begin to dictate what kind of data the prim contains depending on if it is a prim to represent a cube, a light, a mesh, etc.
 
 ```{code-cell}
 :test-tags: [prims-define-prim]
@@ -120,7 +120,7 @@ Note in the USDA output that the prim with the name "hello" does not have a type
 
 ### Example 2: Defining a Sphere Prim
 
-While the [`DefinePrim()`](https://openusd.org/release/api/class_usd_stage.html#a6151ae804f7145e451d9aafdde347730) API provides a generic way to create any type of prim. Many prim types have specific API to create and interact with them.
+While the {usdcpp}`UsdStage::DefinePrim` API provides a generic way to create any type of prim. Many prim types have specific API to create and interact with them.
 
 
 ```{code-cell}
@@ -179,7 +179,7 @@ The prim hierarchy that we have created is:
     - *GroupTransform*
         - *Cube*
 
-By nesting prims in this way, a hierarchical scenegraph begins to take shape. In this example, "Geometry" is the root prim. In other words, "Geometry" is a direct child of the pseudo-root `/`. We are also defining three different types of prims here: [`Scope`](https://openusd.org/release/api/class_usd_geom_scope.html), [`Xform`](https://openusd.org/release/api/class_usd_geom_xform.html), and [`Cube`](https://openusd.org/release/api/class_usd_geom_cube.html). We will look at these prim types more closely in other lessons, but for a brief description:
+By nesting prims in this way, a hierarchical scenegraph begins to take shape. In this example, "Geometry" is the root prim. In other words, "Geometry" is a direct child of the pseudo-root `/`. We are also defining three different types of prims here: {usdcpp}`UsdGeomScope`, {usdcpp}`UsdGeomXform`, and {usdcpp}`UsdGeomCube`. We will look at these prim types more closely in other lessons, but for a brief description:
 
 - **Xform**: Defines a transform (translate, rotation, scale)
 - **Scope**: Is a simple container that does not hold transform data
@@ -187,7 +187,7 @@ By nesting prims in this way, a hierarchical scenegraph begins to take shape. In
 
 ### Example 4: Does the Prim Exist?
 
-When working with large amounts of data it is key to make sure that a prim exists before trying to override it. We can get the child of a prim using [`GetChild()`](https://openusd.org/release/api/class_usd_prim.html#a8c0974bbd49570564f0096ce982ff64a). If it was unable to find the child, it will return an invalid `UsdPrim`. An invalid prim will evaluate as `False` when treated as a boolean. You can use [`Usd.Object.IsValid()`](https://openusd.org/release/api/class_usd_object.html#ac532c4b500b1a85ea22217f2c65a70ed) to check if the prim is valid or exists. 
+When working with large amounts of data it is key to make sure that a prim exists before trying to override it. We can get the child of a prim using {usdcpp}`UsdPrim::GetChild`. If it was unable to find the child, it will return an invalid `UsdPrim`. An invalid prim will evaluate as `False` when treated as a boolean. You can use {usdcpp}`UsdObject::IsValid` to check if the prim is valid or exists.
 
 ```{code-cell}
 :test-tags: [prims-getchild-box]

--- a/docs/stage-setting/properties/attributes.md
+++ b/docs/stage-setting/properties/attributes.md
@@ -87,7 +87,7 @@ Properties are the other kind of namespace object in OpenUSD. Whereas prims prov
 
 There are two types of properties: attributes and relationships.
 
-To retrieve the properties of a prim, we would use the [`GetProperties`](https://openusd.org/release/api/class_usd_prim.html#aa3d8915481ff6280c22c60de4a833423) method. For this demonstration we will be using [`GetPropertyNames()`](https://openusd.org/release/api/class_usd_prim.html#a24377e6ababf44be9534a68046ebb7b8) instead to retrieve the names of the properties. This will not grab the properties themselves, but a list of the names of the properties. Use [`GetProperties`](https://openusd.org/release/api/class_usd_prim.html#aa3d8915481ff6280c22c60de4a833423) to retrieve the properties themselves.
+To retrieve the properties of a prim, we would use the {usdcpp}`UsdPrim::GetProperties` method. For this demonstration we will be using {usdcpp}`UsdPrim::GetPropertyNames` instead to retrieve the names of the properties. This will not grab the properties themselves, but a list of the names of the properties. Use {usdcpp}`UsdPrim::GetProperties` to retrieve the properties themselves.
 
 
 ```{note}
@@ -139,11 +139,11 @@ def Sphere "Sphere"{
 }
 ```
 
-We interact with attributes through the [`UsdAttribute` API](https://openusd.org/release/api/class_usd_attribute.html).
+We interact with attributes through the {usdcpp}`UsdAttribute` API.
 
-Each prim type has their own set of properties and corresponding functions to retrieve them. Since our sphere is of type [`UsdGeom.Sphere`](https://openusd.org/release/api/class_usd_geom_sphere.html), we can use the schema-specific API to get and set the radius attribute.
+Each prim type has their own set of properties and corresponding functions to retrieve them. Since our sphere is of type {usdcpp}`UsdGeomSphere`, we can use the schema-specific API to get and set the radius attribute.
 
-[`GetRadiusAttr()`](https://openusd.org/release/api/class_usd_geom_sphere.html#abae017e4bd8775bc725d7df41317df85) will return a [`UsdAttribute`](https://openusd.org/release/api/class_usd_attribute.html) object that can be used to modify the attribute. Which means it will not retrieve the value of the attribute. To get the value of an attribute, use the [`Get()`](https://openusd.org/release/api/class_usd_attribute.html#a9d41bc223be86408ba7d7f74df7c35a9) method.
+{usdcpp}`UsdGeomSphere::GetRadiusAttr` will return a {usdcpp}`UsdAttribute` object that can be used to modify the attribute. Which means it will not retrieve the value of the attribute. To get the value of an attribute, use {usdcpp}`UsdAttribute::Get`.
 
 For example, to get the value of the radius attribute, we would use the following snippet.
 
@@ -151,9 +151,9 @@ For example, to get the value of the radius attribute, we would use the followin
 sphere_prim.GetRadiusAttr().Get()
 ```
 
-Let's use the [`Get()`](https://openusd.org/release/api/class_usd_attribute.html#a9d41bc223be86408ba7d7f74df7c35a9) method for the `radius`, `displayColor`, and `extent` attributes.
+Let's use the {usdcpp}`UsdAttribute::Get` method for the `radius`, `displayColor`, and `extent` attributes.
 
-Since we have not explicitly authored any attribute values, [`Get()`](https://openusd.org/release/api/class_usd_attribute.html#a9d41bc223be86408ba7d7f74df7c35a9) will return the fallback value that was defined in the schema. 
+Since we have not explicitly authored any attribute values, {usdcpp}`UsdAttribute::Get` will return the fallback value that was defined in the schema.
 
 ```{note}
 The attribute values will not show up in `.usda`, however the values are coming from the fallback value defined in the sphere schema. USD is applying {term}`value resolution <Value Resolution>` to retrieve the values.
@@ -197,7 +197,7 @@ DisplayUSD(file_path, show_usd_code=True)
 
 ### Example 3: Setting Attribute Values
 
-In the last example, we used the [`Get()`](https://openusd.org/release/api/class_usd_attribute.html#a9d41bc223be86408ba7d7f74df7c35a9) method to retrieve the value of the attribute. To set the values, we use the [`Set()`](https://openusd.org/release/api/class_usd_attribute.html#a151e6fde58bbd911da8322911a3c0079) method.
+In the last example, we used the {usdcpp}`UsdAttribute::Get` method to retrieve the value of the attribute. To set the values, we use the {usdcpp}`UsdAttribute::Set` method.
 
 Here is an example of setting a value to the radius attribute.
 
@@ -213,11 +213,11 @@ def Sphere "Sphere"{
 }
 ```
 
-Based on our last modification, if we were to use [`Get()`](https://openusd.org/release/api/class_usd_attribute.html#a9d41bc223be86408ba7d7f74df7c35a9) it would return `100`.
+Based on our last modification, if we were to use {usdcpp}`UsdAttribute::Get` it would return `100`.
 
-When getting attribute values, USD will apply {term}`value resolution <Value Resolution>` since we authored a default value. The [`Get()`](https://openusd.org/release/api/class_usd_attribute.html#a9d41bc223be86408ba7d7f74df7c35a9) method will retrieve the value of the attribute. To set the values, we use the [`Set()`](https://openusd.org/release/api/class_usd_attribute.html#a151e6fde58bbd911da8322911a3c0079) method. This will resolve to the authored value rather than the fallback value from the sphere schema.
+When getting attribute values, USD will apply {term}`value resolution <Value Resolution>` since we authored a default value. The {usdcpp}`UsdAttribute::Get` method will retrieve the value of the attribute. To set the values, we use the {usdcpp}`UsdAttribute::Set` method. This will resolve to the authored value rather than the fallback value from the sphere schema.
 
-Now let's modify the `size`, `displayColor`, and `extent` attributes of the cube by using [`Set()`](https://openusd.org/release/api/class_usd_attribute.html#a151e6fde58bbd911da8322911a3c0079).
+Now let's modify the `size`, `displayColor`, and `extent` attributes of the cube by using {usdcpp}`UsdAttribute::Set`.
 
 ```{code-cell}
 :test-tags: [attributes-set-values]

--- a/docs/stage-setting/stage.md
+++ b/docs/stage-setting/stage.md
@@ -87,9 +87,9 @@ At its core, an OpenUSD stage refers to a top-level USD file that serves as a co
 
 Some of the functions we will use to access the stage will be the following:
 
-- [`Usd.Stage.CreateNew()`](https://openusd.org/release/api/class_usd_stage.html#a50c3f0a412aee9decb010787e5ca2e3e): Creates a new empty USD Stage where 3D scenes are assembled.
-- [`Usd.Stage.Open()`](https://openusd.org/release/api/class_usd_stage.html#ad3e185c150ee38ae13fb76115863d108): Opens an existing USD file as a stage.
-- [`Usd.Stage.Save()`](https://openusd.org/release/api/class_usd_stage.html#adefa2f7ebfc4d8c09f0cd54419aa36c4): Saves the current stage of a USD stage back to a file. If there are multiple layers in the stage, all edited layers that contribute to the stage are being saved. In our case, all edits are being done in a single layer.
+- {usdcpp}`UsdStage::CreateNew`: Creates a new empty USD Stage where 3D scenes are assembled.
+- {usdcpp}`UsdStage::Open`: Opens an existing USD file as a stage.
+- {usdcpp}`UsdStage::Save`: Saves the current stage of a USD stage back to a file. If there are multiple layers in the stage, all edited layers that contribute to the stage are being saved. In our case, all edits are being done in a single layer.
 
 ```{code-cell}
 :test-tags: [stage-create-new]

--- a/docs/stage-setting/timecodes-timesamples.md
+++ b/docs/stage-setting/timecodes-timesamples.md
@@ -142,9 +142,9 @@ DisplayUSD("_assets/timecode_sample.usda", show_usd_code=True)
 
 Time code specifies an exact frame or moment in the animation timeline. It allows for precise control over the timing of changes to properties, enabling smooth and accurate animation of 3D objects. 
 
-A [`Usd.TimeCode`](https://openusd.org/release/api/class_usd_time_code.html) is therefore a unitless, generic time measurement that serves as the ordinate for time-sampled data in USD files. [`Usd.Stage`](https://openusd.org/release/api/class_usd_stage.html) defines the mapping of time codes to units like seconds and frames.
+A {usdcpp}`UsdTimeCode` is therefore a unitless, generic time measurement that serves as the ordinate for time-sampled data in USD files. {usdcpp}`UsdStage` defines the mapping of time codes to units like seconds and frames.
 
-To set the stage's `startTimeCode` and `endTimeCode` metadata, use the [`SetStartTimeCode()`](https://openusd.org/release/api/class_usd_stage.html#aef35e121cd9662129b6e338e85ceab44) and [`SetEndTimeCode()`](https://openusd.org/release/api/class_usd_stage.html#a05e5e8a51041bc7f9b7f1165ccec9fa4) methods.
+To set the stage's `startTimeCode` and `endTimeCode` metadata, use the {usdcpp}`UsdStage::SetStartTimeCode` and {usdcpp}`UsdStage::SetEndTimeCode` methods.
 
 ```{code-cell}
 :test-tags: [timecodes-set-start-end]
@@ -176,9 +176,9 @@ Time samples represent a collection of attribute values at various points in tim
 
 When animating an attribute, you define a time code at which the value should be applied. These values are then interpolated between the time samples to get the value that should be applied at the current time code.
 
-To assign a value at a particular time code, use the [`Set()`](https://openusd.org/release/api/class_usd_attribute.html#a7fd0957eecddb7cfcd222cccd51e23e6) method. 
+To assign a value at a particular time code, use the {usdcpp}`UsdAttribute::Set` method.
 
-[`Set()`](https://openusd.org/release/api/class_usd_attribute.html#a7fd0957eecddb7cfcd222cccd51e23e6) takes two arguments: the time code and the value to assign.
+{usdcpp}`UsdAttribute::Set` takes two arguments: the time code and the value to assign.
 
 For example, if you want to set the size of a cube to `1` at time code `1` and `10` at time code `60`:
 
@@ -193,7 +193,7 @@ cube_size_attr.Set(time=60, value=10)
 
 USD will interpolate the values for the cube's size attribute between set time samples.
 
-Let's create a sphere that moves up and down using the [`XformCommonAPI`](https://openusd.org/release/api/class_usd_geom_xform_common_a_p_i.html).
+Let's create a sphere that moves up and down using {usdcpp}`UsdGeomXformCommonAPI`.
 
 ```{code-cell}
 :test-tags: [timecodes-translation-time-samples]

--- a/docs/stage-setting/usd-file-formats.md
+++ b/docs/stage-setting/usd-file-formats.md
@@ -37,7 +37,7 @@ The file formats used in these lessons are chosen for clarity. In production, fo
 * Reserve usda text for small, human‑readable “interface” layers that mostly reference or sublayer other files, and for debugging or diffing.
 * In general, “prefer crate files” for big data, and keep text to lightweight aggregators.
 
-[See Maximizing USD Performance for the full recommendations](https://openusd.org/release/maxperf.html).
+[See Maximizing USD Performance for the full recommendations](inv:usd:std:doc#maxperf).
 
 ```
 


### PR DESCRIPTION
Made external links to cross project references as mentioned in https://github.com/NVIDIA-Omniverse/LearnOpenUSD/issues/7.

Summary:

### What changed

- Replaced many C++ API links (class/method pages) with `{usdcpp}\...` so they resolve through `USD.tag` instead of pasted URLs.
- Switched several OpenUSD docs / tools / glossary-style targets to `inv:usd:std...` (e.g. FAQ doc, toolset entries like usdcat, user_guides where it worked).
- Touched ~19 lesson/glossary-related files under docs/ (stage-setting, composition, creating-composition-arcs, beyond-basics, scene-description-blueprints, data-exchange, glossary).

### What I did not fully convert

- Kept some absolute URLs where `inv: / {usdcpp}` had no stable inventory or tag entry (e.g. certain API “page front” / annotated-style pages), so the build would stay warning-free.
- Left intentional openusd.org in docs/conf.py (intersphinx base URL) and docs/index.md (homepage link).


### Verification

Ran `uv run sphinx-build -M html docs/ docs/_build/` so cross-refs are exercised at build time; final state was clean on that run after settling ambiguous targets.

---

Commit signed off as usual.