### PR TITLE
Add Spline Animation #8

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -354,11 +354,11 @@ def test_create_stage(run_notebook):
 
 ### License Header
 
-Every new `.md` with executable code or `.py` file must include the Apache 2.0 SPDX license header:
+Every new `.md` with executable code or `.py` file must include the Apache 2.0 SPDX license header. Substitute the four-digit year the file is created for `<YEAR>`:
 
 ```markdown
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) <YEAR> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/_static/data/glossary-graph-structure.js
+++ b/docs/_static/data/glossary-graph-structure.js
@@ -15,6 +15,7 @@ const graphStructure = {
     nodes: [
         { id: 'Active and Inactive', label: 'Active and Inactive', category: 'stage-population' },
         { id: 'Animated Value', label: 'Animated Value', category: 'value-resolution' },
+        { id: 'Animation Spline', label: 'Animation Spline', category: 'value-resolution' },
         { id: 'API Schema', label: 'API Schema', category: 'schemas' },
         { id: 'Assembly', label: 'Assembly', category: 'multi-domain-schemas' },
         { id: 'Asset', label: 'Asset', category: 'multi-domain-schemas' },
@@ -126,6 +127,9 @@ const graphStructure = {
         { source: 'Attribute', target: 'Animated Value', label: 'may have' },
         { source: 'Attribute', target: 'Attribute Block', label: 'may have' },
         { source: 'Animated Value', target: 'Time Sample', label: 'contains' },
+        { source: 'Animated Value', target: 'Animation Spline', label: 'contains' },
+        { source: 'Animation Spline', target: 'Time Code', label: 'contains' },
+        { source: 'Animation Spline', target: 'Interpolation', label: 'has' },
         { source: 'Time Sample', target: 'Time Code', label: 'contains' },
         { source: 'Time Sample', target: 'Interpolation', label: 'has' },
         { source: 'Property', target: 'Property Stack', label: 'has' },

--- a/docs/beyond-basics/index.md
+++ b/docs/beyond-basics/index.md
@@ -7,7 +7,8 @@ In this module, we'll go deeper into production-ready techniques that power real
 By the end of this module, you'll understand how to:
 
 - **Work with {term}`primvars <Primvar>`** - attach rendering data like UVs, vertex colors, and custom attributes to geometry
-- **Leverage {term}`value resolution <Value Resolution>`** - understand how USD resolves attribute values from multiple composition sources
+- **Leverage {term}`value resolution <Value Resolution>`** - understand how USD resolves attribute values from multiple composition sources (including animation splines)
+- **Author {term}`animation splines <Animated Value>`** - represent looping and extrapolated motion with `pxr.Ts` splines on attributes
 - **Create custom {term}`properties <Property>`** - extend USD's data model with user-defined attributes for specific workflows  
 - **Manage scene complexity** - use {term}`active/inactive <Active and Inactive>` {term}`prims <Prim>` for efficient, non-destructive scene management
 - **Utilize {term}`model <Model>` {term}`kinds <Kind>`** - structure assets using {term}`component <Component>`, {term}`assembly <Assembly>`, and {term}`group <Group>` hierarchies
@@ -35,6 +36,7 @@ These skills prepare you for the most advanced USD topics: creating custom {term
 Overview <self>
 primvars
 value-resolution
+spline-animation
 custom-properties
 active-inactive-prims
 model-kinds

--- a/docs/beyond-basics/index.md
+++ b/docs/beyond-basics/index.md
@@ -8,7 +8,7 @@ By the end of this module, you'll understand how to:
 
 - **Work with {term}`primvars <Primvar>`** - attach rendering data like UVs, vertex colors, and custom attributes to geometry
 - **Leverage {term}`value resolution <Value Resolution>`** - understand how USD resolves attribute values from multiple composition sources (including animation splines)
-- **Author {term}`animation splines <Animated Value>`** - represent looping and extrapolated motion with `pxr.Ts` splines on attributes
+- **Author {term}`animation splines <Animation Spline>`** - represent looping and extrapolated motion with `pxr.Ts` splines on attributes
 - **Create custom {term}`properties <Property>`** - extend USD's data model with user-defined attributes for specific workflows  
 - **Manage scene complexity** - use {term}`active/inactive <Active and Inactive>` {term}`prims <Prim>` for efficient, non-destructive scene management
 - **Utilize {term}`model <Model>` {term}`kinds <Kind>`** - structure assets using {term}`component <Component>`, {term}`assembly <Assembly>`, and {term}`group <Group>` hierarchies

--- a/docs/beyond-basics/spline-animation.md
+++ b/docs/beyond-basics/spline-animation.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +11,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific governing permissions and
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 jupytext:
@@ -48,12 +48,23 @@ The embedded **3D previews** in this site use GLB conversion that keys off **tim
 
 ## Working With Python
 
-The `Ts` package provides `Ts.Spline`, `Ts.Knot`, `Ts.LoopParams`, and `Ts.Extrapolation`. You construct a spline for an attribute’s value type (for example `"float"`), add knots, optionally configure loop or extrapolation settings, then call `UsdAttribute.SetSpline`. Reading `attr.Get(timeCode)` evaluates the composed spline at that time, subject to layer time mapping.
+The `Ts` package provides `Ts.Spline`, `Ts.Knot`, `Ts.LoopParams`, and `Ts.Extrapolation`. You construct a spline for an attribute’s value type (for example `"float"`), add knots, optionally configure loop or extrapolation settings, then call `UsdAttribute.SetSpline`.
+
+```{attention}
+Splines are only supported on **floating-point scalar** attributes: `half`, `float`, and `double`. `Ts.Spline` raises an error for any other type name, so you cannot spline-animate `xformOp:translate` (a `double3`) directly. Use the single-axis transform ops instead—`xformOp:rotateZ` is a `float` and `xformOp:translateX` is a `double`—or author one spline per component. The examples below pass `attr.GetTypeName()` straight to `Ts.Spline` only because the ops they use are already scalar.
+```
+
+Reading `attr.Get(timeCode)` evaluates the composed spline at that time, subject to layer time mapping—**provided no time samples are authored for that attribute at a stronger or equal location**. Time samples win over splines during {term}`value resolution <Value Resolution>`, so an attribute carrying both returns the sampled value and `attr.HasSpline()` reports `False`.
+
+The snippet below is a complete, self-contained example:
 
 ```python
-from pxr import UsdGeom, Ts
+from pxr import Usd, UsdGeom, Ts
 
-# xform is a UsdGeom.Xformable
+stage = Usd.Stage.CreateInMemory()
+xform = UsdGeom.Xform.Define(stage, "/World/Spinner")
+
+# xformOp:rotateZ is a float attribute, which splines support
 spin = xform.AddRotateZOp(opSuffix="yaw")
 attr = spin.GetAttr()
 type_name = str(attr.GetTypeName())
@@ -296,7 +307,8 @@ The right instance sees source time `t - 24` at global time `t`, so at global fr
 
 1. **Splines complement time samples** on the same attributes: you can author smooth, looping, or extrapolated motion without dense sample lists, where tooling supports spline authoring.
 2. **`pxr.Ts` + `SetSpline`** is the usual Python path for constructing curves, inner loops, and extrapolation before saving USD.
-3. **Resolution is per time code**: `Get(t)` evaluates the composed spline (after strength ordering and time mapping), consistent with how samples and `timeCodesPerSecond` interact across layers.
-4. **Layer offsets retime splines** just like samples—plan for held behavior outside knot coverage if you rely on offsets or short authored ranges.
+3. **Splines are for `half`, `float`, and `double` attributes only**—animate single-axis transform ops, or one spline per component, rather than vector types like `double3`.
+4. **Resolution is per time code**: `Get(t)` evaluates the composed spline (after strength ordering and time mapping), consistent with how samples and `timeCodesPerSecond` interact across layers. Time samples at a stronger or equal location take precedence over a spline.
+5. **Layer offsets retime splines** just like samples—plan for held behavior outside knot coverage if you rely on offsets or short authored ranges.
 
 For how defaults, samples, splines, and clips combine in the attribute stack, see [Value resolution](value-resolution.md).

--- a/docs/beyond-basics/spline-animation.md
+++ b/docs/beyond-basics/spline-animation.md
@@ -26,11 +26,15 @@ kernelspec:
   name: python3
 ---
 
-# Spline animation
+# Spline Animation
+
+## What Is Spline Animation?
 
 {term}`Time samples <Time Sample>` are a straightforward way to animate {term}`attributes <Attribute>`: you author values at chosen {term}`time codes <Time Code>`, and USD interpolates between them (for example, linearly). That model is a good fit when motion is simple or nearly piecewise linear.
 
-**Animation splines** store a curve defined by **knots** (time-value keys), tangent data, and interpolation modes between knots. Splines can represent smoother or sparser animation than dense time-sample sequences, and they support **inner loops** (repeating a prototype segment with a value offset) and **extrapolation** past the authored knot range (for example, repeating the whole curve). Pipeline tools and DCC exports can author splines directly on attributes that support them.
+An {term}`animation spline <Animation Spline>` stores a curve defined by **knots** (time-value keys), tangent data, and interpolation modes between knots. Splines can represent smoother or sparser animation than dense time-sample sequences, and they support **inner loops** (repeating a prototype segment with a value offset) and **extrapolation** past the authored knot range (for example, repeating the whole curve). Pipeline tools and DCC exports can author splines directly on attributes that support them.
+
+## How Does It Work?
 
 This lesson shows how to build splines with the Python `pxr.Ts` helpers, attach them to a transform operation with `UsdAttribute.SetSpline`, and see how {term}`layer offsets <Layer Offset>` apply to spline-evaluated motion the same way they do for time samples. For the full rules engine that merges defaults, time samples, splines, and more, see {term}`value resolution <Value Resolution>`.
 
@@ -42,7 +46,7 @@ Stage timing metadata (`timeCodesPerSecond`, `startTimeCode`, `endTimeCode`) sti
 The embedded **3D previews** in this site use GLB conversion that keys off **time samples**, not raw spline payloads. Each example calls `DisplayUSD(..., bake_splines_for_display=True)`, which writes a temporary flattened USD and **evaluates splines into dense samples** for the viewer only. Your saved `_assets/*.usda` files stay spline-authored; open them in **usdview** to inspect splines directly.
 ```
 
-## Working with Python
+## Working With Python
 
 The `Ts` package provides `Ts.Spline`, `Ts.Knot`, `Ts.LoopParams`, and `Ts.Extrapolation`. You construct a spline for an attribute’s value type (for example `"float"`), add knots, optionally configure loop or extrapolation settings, then call `UsdAttribute.SetSpline`. Reading `attr.Get(timeCode)` evaluates the composed spline at that time, subject to layer time mapping.
 
@@ -59,6 +63,14 @@ spline.SetKnot(
         typeName=type_name,
         time=0,
         value=0,
+        nextInterp=Ts.InterpLinear,
+    )
+)
+spline.SetKnot(
+    Ts.Knot(
+        typeName=type_name,
+        time=48,
+        value=180,
         nextInterp=Ts.InterpLinear,
     )
 )
@@ -147,9 +159,9 @@ The `.spline` payload in USD text lists the loop parameters and knot data. At ev
 
 ### Example 2: Post extrapolation
 
-Without extrapolation, querying times past the last knot typically **holds** the last value. Setting **post extrapolation** to repeat the curve lets motion continue for the rest of the stage range (or until another rule applies).
+Without extrapolation, querying times past the last knot **holds** the last value. Setting **post extrapolation** lets motion continue for the rest of the stage range (or until another rule applies).
 
-This example rocks a cube on the Y axis from -12° to 12° over 60 frames, then repeats that pattern.
+This example rocks a cube on the Y axis from -12° to 12° over 60 frames, then keeps swinging by mirroring that segment with `Ts.ExtrapLoopOscillate`.
 
 ```{code-cell}
 :test-tags: [spline-animation-extrapolation]
@@ -192,14 +204,14 @@ spline.SetKnot(
         nextInterp=Ts.InterpCurve,
     )
 )
-spline.SetPostExtrapolation(Ts.Extrapolation(Ts.ExtrapLoopRepeat))
+spline.SetPostExtrapolation(Ts.Extrapolation(Ts.ExtrapLoopOscillate))
 rock_attr.SetSpline(spline)
 
 stage.Save()
 
-print(f"t=30 (within authored span): {rock_attr.Get(30)}")
-print(f"t=90 (first repeated cycle): {rock_attr.Get(90)}")
-print(f"t=120 (continued extrapolation): {rock_attr.Get(120)}")
+print(f"t=45 (within authored span): {rock_attr.Get(45):.2f}")
+print(f"t=75 (past the last knot, swinging back): {rock_attr.Get(75):.2f}")
+print(f"t=120 (one full oscillation later): {rock_attr.Get(120):.2f}")
 ```
 
 ```{code-cell}
@@ -207,7 +219,7 @@ print(f"t=120 (continued extrapolation): {rock_attr.Get(120)}")
 DisplayUSD(spline_extrap_path, show_usd_code=True, bake_splines_for_display=True)
 ```
 
-`Ts.ExtrapLoopRepeat` continues the spline by repeating the authored segment; the value step between cycles comes from the difference between the first and last knot values.
+`Ts.ExtrapLoopOscillate` continues the spline by mirroring the authored segment, so the cube swings back to -12° and repeats. Choose the mode that matches the motion: `Ts.ExtrapLoopRepeat` repeats the segment's *shape* and offsets each cycle by the difference between the first and last knot values, which would keep turning this cube in one direction instead of rocking it.
 
 ### Example 3: Layer offsets and spline time
 
@@ -278,9 +290,9 @@ print(f"At global t={t_query}, right rig X (offset +24): {late.Get(t_query)}")
 DisplayUSD(offset_scene_path, show_usd_code=True, bake_splines_for_display=True)
 ```
 
-The right instance sees source time \(t - 24\) at global time \(t\), so at global frame 24 it is only at the start of its slide. For deeper retiming, {term}`value clips <Value Clips>` remain the heavier-weight option.
+The right instance sees source time `t - 24` at global time `t`, so at global frame 24 it is only at the start of its slide. For deeper retiming, {term}`value clips <Value Clips>` remain the heavier-weight option.
 
-## Key takeaways
+## Key Takeaways
 
 1. **Splines complement time samples** on the same attributes: you can author smooth, looping, or extrapolated motion without dense sample lists, where tooling supports spline authoring.
 2. **`pxr.Ts` + `SetSpline`** is the usual Python path for constructing curves, inner loops, and extrapolation before saving USD.

--- a/docs/beyond-basics/spline-animation.md
+++ b/docs/beyond-basics/spline-animation.md
@@ -1,0 +1,290 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific governing permissions and
+# limitations under the License.
+
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.17.2
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Spline animation
+
+{term}`Time samples <Time Sample>` are a straightforward way to animate {term}`attributes <Attribute>`: you author values at chosen {term}`time codes <Time Code>`, and USD interpolates between them (for example, linearly). That model is a good fit when motion is simple or nearly piecewise linear.
+
+**Animation splines** store a curve defined by **knots** (time-value keys), tangent data, and interpolation modes between knots. Splines can represent smoother or sparser animation than dense time-sample sequences, and they support **inner loops** (repeating a prototype segment with a value offset) and **extrapolation** past the authored knot range (for example, repeating the whole curve). Pipeline tools and DCC exports can author splines directly on attributes that support them.
+
+This lesson shows how to build splines with the Python `pxr.Ts` helpers, attach them to a transform operation with `UsdAttribute.SetSpline`, and see how {term}`layer offsets <Layer Offset>` apply to spline-evaluated motion the same way they do for time samples. For the full rules engine that merges defaults, time samples, splines, and more, see {term}`value resolution <Value Resolution>`.
+
+```{note}
+Stage timing metadata (`timeCodesPerSecond`, `startTimeCode`, `endTimeCode`) still defines how time codes map to seconds for playback. When layers disagree on frame rate, USD reconciles timing during value resolution; see [Units in OpenUSD](units.md) for `timeCodesPerSecond` behavior.
+```
+
+```{tip}
+The embedded **3D previews** in this site use GLB conversion that keys off **time samples**, not raw spline payloads. Each example calls `DisplayUSD(..., bake_splines_for_display=True)`, which writes a temporary flattened USD and **evaluates splines into dense samples** for the viewer only. Your saved `_assets/*.usda` files stay spline-authored; open them in **usdview** to inspect splines directly.
+```
+
+## Working with Python
+
+The `Ts` package provides `Ts.Spline`, `Ts.Knot`, `Ts.LoopParams`, and `Ts.Extrapolation`. You construct a spline for an attribute’s value type (for example `"float"`), add knots, optionally configure loop or extrapolation settings, then call `UsdAttribute.SetSpline`. Reading `attr.Get(timeCode)` evaluates the composed spline at that time, subject to layer time mapping.
+
+```python
+from pxr import UsdGeom, Ts
+
+# xform is a UsdGeom.Xformable
+spin = xform.AddRotateZOp(opSuffix="yaw")
+attr = spin.GetAttr()
+type_name = str(attr.GetTypeName())
+spline = Ts.Spline(type_name)
+spline.SetKnot(
+    Ts.Knot(
+        typeName=type_name,
+        time=0,
+        value=0,
+        nextInterp=Ts.InterpLinear,
+    )
+)
+attr.SetSpline(spline)
+```
+
+For extrapolation modes, knot tangents, and multi-dimensional types, see the OpenUSD C++ documentation for [`TsSpline`](https://openusd.org/release/api/class_ts_spline.html).
+
+## Examples
+
+```{tip}
+You can run these examples locally as Jupyter notebooks. See [How to Run Notebooks Locally](../jupyter-notebook-setup.md) for setup instructions.
+```
+
++++ {"tags": ["remove-cell"]}
+>**NOTE**: Before starting make sure to run the cell below. This will install the relevant OpenUSD libraries that will be used through this notebook.
++++
+```{code-cell}
+:tags: [remove-input]
+:test-tags: [spline-animation-setup]
+from lousd.utils.visualization import DisplayUSD
+from lousd.utils.helperfunctions import create_new_stage
+```
+
+### Example 1: Inner loop on a rotation
+
+Here a single linear segment from 0° to 90° over 24 frames is repeated four times (one prototype plus three post-loops) with a **value offset** of 90° each time, so the cube completes a full 360° turn without authoring every quarter-turn as separate samples.
+
+```{code-cell}
+:test-tags: [spline-animation-inner-loop]
+:emphasize-lines: 22-38
+from pxr import Usd, UsdGeom, Ts
+
+spline_loop_path = "_assets/spline_inner_loop.usda"
+stage = create_new_stage(spline_loop_path)
+UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+stage.SetTimeCodesPerSecond(24)
+stage.SetStartTimeCode(0)
+stage.SetEndTimeCode(96)
+
+world = UsdGeom.Xform.Define(stage, "/World")
+stage.SetDefaultPrim(world.GetPrim())
+
+xform = UsdGeom.Xform.Define(stage, "/World/RotatingCube")
+cube = UsdGeom.Cube.Define(stage, "/World/RotatingCube/Geometry")
+cube.GetSizeAttr().Set(1.2)
+cube.GetDisplayColorAttr().Set([(0.35, 0.65, 0.95)])
+
+yaw = xform.AddRotateZOp(opSuffix="yaw")
+yaw_attr = yaw.GetAttr()
+type_name = str(yaw_attr.GetTypeName())
+
+spline = Ts.Spline(type_name)
+spline.SetKnot(
+    Ts.Knot(
+        typeName=type_name,
+        time=0,
+        value=0,
+        nextInterp=Ts.InterpLinear,
+    )
+)
+loop_params = Ts.LoopParams()
+loop_params.protoStart = 0
+loop_params.protoEnd = 24
+loop_params.numPostLoops = 3
+loop_params.valueOffset = 90
+spline.SetInnerLoopParams(loop_params)
+yaw_attr.SetSpline(spline)
+
+stage.Save()
+
+mid_proto = 12
+print(f"Rotation at t=0: {yaw_attr.Get(0)}")
+print(f"Rotation at t={mid_proto} (mid prototype): {yaw_attr.Get(mid_proto)}")
+print(f"Rotation at t=24 (end of first loop): {yaw_attr.Get(24)}")
+print(f"Rotation at t=48: {yaw_attr.Get(48)}")
+print(f"Attribute stores a spline: {yaw_attr.HasSpline()}")
+```
+
+```{code-cell}
+:tags: [remove-input]
+DisplayUSD(spline_loop_path, show_usd_code=True, bake_splines_for_display=True)
+```
+
+The `.spline` payload in USD text lists the loop parameters and knot data. At evaluation time, value resolution samples that curve at the requested time code.
+
+### Example 2: Post extrapolation
+
+Without extrapolation, querying times past the last knot typically **holds** the last value. Setting **post extrapolation** to repeat the curve lets motion continue for the rest of the stage range (or until another rule applies).
+
+This example rocks a cube on the Y axis from -12° to 12° over 60 frames, then repeats that pattern.
+
+```{code-cell}
+:test-tags: [spline-animation-extrapolation]
+:emphasize-lines: 18-26
+from pxr import Usd, UsdGeom, Ts
+
+spline_extrap_path = "_assets/spline_extrapolation.usda"
+stage = create_new_stage(spline_extrap_path)
+UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+stage.SetTimeCodesPerSecond(30)
+stage.SetStartTimeCode(0)
+stage.SetEndTimeCode(150)
+
+world = UsdGeom.Xform.Define(stage, "/World")
+stage.SetDefaultPrim(world.GetPrim())
+
+xform = UsdGeom.Xform.Define(stage, "/World/RockingCube")
+cube = UsdGeom.Cube.Define(stage, "/World/RockingCube/Geometry")
+cube.GetSizeAttr().Set(1.0)
+cube.GetDisplayColorAttr().Set([(0.9, 0.55, 0.25)])
+
+rock = xform.AddRotateYOp(opSuffix="rock")
+rock_attr = rock.GetAttr()
+type_name = str(rock_attr.GetTypeName())
+
+spline = Ts.Spline(type_name)
+spline.SetKnot(
+    Ts.Knot(
+        typeName=type_name,
+        time=0,
+        value=-12,
+        nextInterp=Ts.InterpCurve,
+    )
+)
+spline.SetKnot(
+    Ts.Knot(
+        typeName=type_name,
+        time=60,
+        value=12,
+        nextInterp=Ts.InterpCurve,
+    )
+)
+spline.SetPostExtrapolation(Ts.Extrapolation(Ts.ExtrapLoopRepeat))
+rock_attr.SetSpline(spline)
+
+stage.Save()
+
+print(f"t=30 (within authored span): {rock_attr.Get(30)}")
+print(f"t=90 (first repeated cycle): {rock_attr.Get(90)}")
+print(f"t=120 (continued extrapolation): {rock_attr.Get(120)}")
+```
+
+```{code-cell}
+:tags: [remove-input]
+DisplayUSD(spline_extrap_path, show_usd_code=True, bake_splines_for_display=True)
+```
+
+`Ts.ExtrapLoopRepeat` continues the spline by repeating the authored segment; the value step between cycles comes from the difference between the first and last knot values.
+
+### Example 3: Layer offsets and spline time
+
+{term}`References <Reference>` can carry an `Sdf.LayerOffset` (scale and offset on the **source** layer’s time line). The same rules apply when the referenced animation is driven by splines: evaluation uses the mapped time when resolving values on the composed stage.
+
+```{code-cell}
+:test-tags: [spline-animation-layer-offset]
+:emphasize-lines: 28-42
+from pxr import Usd, UsdGeom, Ts, Sdf
+
+slide_asset_path = "_assets/spline_slide_rig.usda"
+rig_stage = create_new_stage(slide_asset_path)
+UsdGeom.SetStageUpAxis(rig_stage, UsdGeom.Tokens.y)
+rig_stage.SetTimeCodesPerSecond(24)
+rig_stage.SetStartTimeCode(0)
+rig_stage.SetEndTimeCode(48)
+
+rig = UsdGeom.Xform.Define(rig_stage, "/SlideRig")
+rig_stage.SetDefaultPrim(rig.GetPrim())
+UsdGeom.Cube.Define(rig_stage, "/SlideRig/Geometry").GetSizeAttr().Set(0.6)
+
+slide = rig.AddTranslateXOp(opSuffix="slide")
+slide_attr = slide.GetAttr()
+type_name = str(slide_attr.GetTypeName())
+
+spline = Ts.Spline(type_name)
+spline.SetKnot(
+    Ts.Knot(typeName=type_name, time=0, value=0, nextInterp=Ts.InterpLinear)
+)
+spline.SetKnot(
+    Ts.Knot(typeName=type_name, time=48, value=4, nextInterp=Ts.InterpLinear)
+)
+slide_attr.SetSpline(spline)
+rig_stage.Save()
+
+offset_scene_path = "_assets/spline_layer_offset_scene.usda"
+scene = create_new_stage(offset_scene_path)
+UsdGeom.SetStageUpAxis(scene, UsdGeom.Tokens.y)
+scene.SetTimeCodesPerSecond(24)
+scene.SetStartTimeCode(0)
+scene.SetEndTimeCode(48)
+
+UsdGeom.Xform.Define(scene, "/World")
+scene.SetDefaultPrim(scene.GetPrimAtPath("/World"))
+
+left_rig = UsdGeom.Xform.Define(scene, "/World/LeftRig")
+left_rig.GetPrim().GetReferences().AddReference(slide_asset_path, primPath="/SlideRig")
+
+right_rig = UsdGeom.Xform.Define(scene, "/World/RightRig")
+right_rig.GetPrim().GetReferences().AddReference(
+    slide_asset_path,
+    primPath="/SlideRig",
+    layerOffset=Sdf.LayerOffset(offset=24),
+)
+
+scene.Save()
+
+composed = Usd.Stage.Open(offset_scene_path)
+early = composed.GetPrimAtPath("/World/LeftRig").GetAttribute("xformOp:translateX:slide")
+late = composed.GetPrimAtPath("/World/RightRig").GetAttribute("xformOp:translateX:slide")
+t_query = 24
+print(f"At global t={t_query}, left rig X (no offset): {early.Get(t_query)}")
+print(f"At global t={t_query}, right rig X (offset +24): {late.Get(t_query)}")
+```
+
+```{code-cell}
+:tags: [remove-input]
+DisplayUSD(offset_scene_path, show_usd_code=True, bake_splines_for_display=True)
+```
+
+The right instance sees source time \(t - 24\) at global time \(t\), so at global frame 24 it is only at the start of its slide. For deeper retiming, {term}`value clips <Value Clips>` remain the heavier-weight option.
+
+## Key takeaways
+
+1. **Splines complement time samples** on the same attributes: you can author smooth, looping, or extrapolated motion without dense sample lists, where tooling supports spline authoring.
+2. **`pxr.Ts` + `SetSpline`** is the usual Python path for constructing curves, inner loops, and extrapolation before saving USD.
+3. **Resolution is per time code**: `Get(t)` evaluates the composed spline (after strength ordering and time mapping), consistent with how samples and `timeCodesPerSecond` interact across layers.
+4. **Layer offsets retime splines** just like samples—plan for held behavior outside knot coverage if you rely on offsets or short authored ranges.
+
+For how defaults, samples, splines, and clips combine in the attribute stack, see [Value resolution](value-resolution.md).

--- a/docs/beyond-basics/spline-animation.md
+++ b/docs/beyond-basics/spline-animation.md
@@ -51,7 +51,9 @@ The embedded **3D previews** in this site use GLB conversion that keys off **tim
 The `Ts` package provides `Ts.Spline`, `Ts.Knot`, `Ts.LoopParams`, and `Ts.Extrapolation`. You construct a spline for an attribute’s value type (for example `"float"`), add knots, optionally configure loop or extrapolation settings, then call `UsdAttribute.SetSpline`.
 
 ```{attention}
-Splines are only supported on **floating-point scalar** attributes: `half`, `float`, and `double`. `Ts.Spline` raises an error for any other type name, so you cannot spline-animate `xformOp:translate` (a `double3`) directly. Use the single-axis transform ops instead—`xformOp:rotateZ` is a `float` and `xformOp:translateX` is a `double`—or author one spline per component. The examples below pass `attr.GetTypeName()` straight to `Ts.Spline` only because the ops they use are already scalar.
+Splines are only supported on **floating-point scalar** attributes: `half`, `float`, and `double`. `Ts.Spline` raises an error for any other type name, so the multi-axis transform ops cannot be splined directly: `AddTranslateOp`, `AddRotateXYZOp`, and `AddScaleOp` all produce a 3-component type (`float3`, `double3`, or `half3`, depending on the precision you request).
+
+Use the single-axis ops instead, or author one spline per component. Single-axis ops are always scalar—`AddRotateZOp` yields a `float` by default and `AddTranslateXOp` a `double`, and passing `UsdGeom.XformOp.PrecisionHalf` or `PrecisionDouble` still gives you `half` or `double`. That is why the examples below can pass `attr.GetTypeName()` straight to `Ts.Spline`: every precision those ops can produce is one splines support.
 ```
 
 Reading `attr.Get(timeCode)` evaluates the composed spline at that time, subject to layer time mapping—**provided no time samples are authored for that attribute at a stronger or equal location**. Time samples win over splines during {term}`value resolution <Value Resolution>`, so an attribute carrying both returns the sampled value and `attr.HasSpline()` reports `False`.

--- a/docs/beyond-basics/value-resolution.md
+++ b/docs/beyond-basics/value-resolution.md
@@ -36,7 +36,7 @@ Value resolution is how OpenUSD figures out the final value of a {term}`property
 
 Even though value resolution combines many pieces of data together, it's different from composition. Understanding this difference helps you work with USD more effectively.
 
-Animated attributes can be driven by {term}`time samples <Time Sample>` or by **animation splines** (curve data authored on the attribute). In both cases, value resolution evaluates the result at the requested {term}`time code <Time Code>`, including temporal mapping from {term}`layer offsets <Layer Offset>` and frame-rate reconciliation for `timeCodesPerSecond`. See [Spline animation](spline-animation.md) for authoring splines with the `pxr.Ts` API.
+Animated attributes can be driven by {term}`time samples <Time Sample>` or by {term}`animation splines <Animation Spline>` (curve data authored on the attribute). In both cases, value resolution evaluates the result at the requested {term}`time code <Time Code>`, including temporal mapping from {term}`layer offsets <Layer Offset>` and frame-rate reconciliation for `timeCodesPerSecond`. See [Spline Animation](spline-animation.md) for authoring splines with the `pxr.Ts` API.
 
 ## How Does It Work?
 
@@ -72,7 +72,7 @@ Attributes are special because they can combine several kinds of time-varying an
 
 1. **{term}`Value clips <Value Clips>`** - Animation data stored in separate files
 2. **{term}`Time samples <Time Sample>`** - Specific values at specific times
-3. **Animation splines** - Curve-based values (knots, tangents, loop and extrapolation settings) evaluated like samples at a given time code
+3. **{term}`Animation splines <Animation Spline>`** - Curve-based values (knots, tangents, loop and extrapolation settings) evaluated like samples at a given time code
 4. **{term}`Default value <Default Value>`** - A non-time-varying value
 
 Value resolution for animated data (clips, time samples, and splines) also accounts for time scaling and offset operators (e.g. {term}`Layer offsets <Layer Offset>`) and {term}`interpolation <Interpolation>` when a {term}`time code <Time Code>` falls between samples or along a spline segment.

--- a/docs/beyond-basics/value-resolution.md
+++ b/docs/beyond-basics/value-resolution.md
@@ -36,9 +36,7 @@ Value resolution is how OpenUSD figures out the final value of a {term}`property
 
 Even though value resolution combines many pieces of data together, it's different from composition. Understanding this difference helps you work with USD more effectively.
 
-```{note}
-Animation splines were recently added to OpenUSD and are also part of value resolution. We'll update this lesson to include them soon.
-```
+Animated attributes can be driven by {term}`time samples <Time Sample>` or by **animation splines** (curve data authored on the attribute). In both cases, value resolution evaluates the result at the requested {term}`time code <Time Code>`, including temporal mapping from {term}`layer offsets <Layer Offset>` and frame-rate reconciliation for `timeCodesPerSecond`. See [Spline animation](spline-animation.md) for authoring splines with the `pxr.Ts` API.
 
 ## How Does It Work?
 
@@ -62,7 +60,7 @@ Animation splines were recently added to OpenUSD and are also part of value reso
 
 For most metadata, the rule is simple: **the strongest opinion wins**. Think of it like a voting system where the most authoritative source gets the final say.
 
-Some metadata like prim {term}`specifier <Specifier>`, {term}`attribute <Attribute>` typeName, and several others have special resolution rules. A common metadata type you may encount with special resolution rules are dictionaries (like `customData`). Dictionaries combine element by element, so if one layer has `customData["keyOne"]` and another has `customData["keyTwo"]`, the final result will have both keys.
+Some metadata like prim {term}`specifier <Specifier>`, {term}`attribute <Attribute>` typeName, and several others have special resolution rules. A common metadata type you may encounter with special resolution rules are dictionaries (like `customData`). Dictionaries combine element by element, so if one layer has `customData["keyOne"]` and another has `customData["keyTwo"]`, the final result will have both keys.
 
 #### Resolving Relationships
 
@@ -70,13 +68,14 @@ Some metadata like prim {term}`specifier <Specifier>`, {term}`attribute <Attribu
 
 #### Resolving Attributes
 
-Attributes are special because they have three possible sources of values at each location:
+Attributes are special because they can combine several kinds of time-varying and static data at each location:
 
 1. **{term}`Value clips <Value Clips>`** - Animation data stored in separate files
 2. **{term}`Time samples <Time Sample>`** - Specific values at specific times
-3. **{term}`Default value <Default Value>`** - A non-time-varying value
+3. **Animation splines** - Curve-based values (knots, tangents, loop and extrapolation settings) evaluated like samples at a given time code
+4. **{term}`Default value <Default Value>`** - A non-time-varying value
 
-Value resolution of attributes in the first two cases also account for time scaling and offset operators (e.g. {term}`Layer offsets <Layer Offset>`) and {term}`interpolation <Interpolation>` for {term}`time codes <Time Code>` that fall between two explicit time samples.
+Value resolution for animated data (clips, time samples, and splines) also accounts for time scaling and offset operators (e.g. {term}`Layer offsets <Layer Offset>`) and {term}`interpolation <Interpolation>` when a {term}`time code <Time Code>` falls between samples or along a spline segment.
 
 ## Working With Python
 

--- a/docs/beyond-basics/value-resolution.md
+++ b/docs/beyond-basics/value-resolution.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,12 +68,14 @@ Some metadata like prim {term}`specifier <Specifier>`, {term}`attribute <Attribu
 
 #### Resolving Attributes
 
-Attributes are special because they can combine several kinds of time-varying and static data at each location:
+Attributes are special because they can combine several kinds of time-varying and static data at each location. When more than one kind is authored at the same location, USD consults them in this order and uses the first one that has a value for the requested {term}`time code <Time Code>`:
 
-1. **{term}`Value clips <Value Clips>`** - Animation data stored in separate files
-2. **{term}`Time samples <Time Sample>`** - Specific values at specific times
-3. **{term}`Animation splines <Animation Spline>`** - Curve-based values (knots, tangents, loop and extrapolation settings) evaluated like samples at a given time code
-4. **{term}`Default value <Default Value>`** - A non-time-varying value
+1. **{term}`Time samples <Time Sample>`** - Specific values at specific times
+2. **{term}`Animation splines <Animation Spline>`** - Curve-based values (knots, tangents, loop and extrapolation settings) evaluated like samples at a given time code
+3. **{term}`Default value <Default Value>`** - A non-time-varying value
+4. **{term}`Value clips <Value Clips>`** - Animation data stored in separate files
+
+A practical consequence: authoring time samples on an attribute that already has a spline hides the spline entirely, and a `default` opinion at a location takes precedence over value clips introduced at that same location.
 
 Value resolution for animated data (clips, time samples, and splines) also accounts for time scaling and offset operators (e.g. {term}`Layer offsets <Layer Offset>`) and {term}`interpolation <Interpolation>` when a {term}`time code <Time Code>` falls between samples or along a spline segment.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -647,9 +647,9 @@ Time Sample
 
     A time sample is a time-value pair that defines an attribute's value at a specific time.
 
-    Time samples are the most common way to author animated values in USD, stored as an ordered collection of time code and value pairs. When querying an attribute at a time code that doesn't exactly match an authored time sample, USD uses interpolation (linear by default) between neighboring samples. Multiple time samples can be authored efficiently and sparsely, with USD automatically handling interpolation and temporal queries.
+    Time samples are the most common way to author animated values in USD, stored as an ordered collection of time code and value pairs. When querying an attribute at a time code that doesn't exactly match an authored time sample, USD uses interpolation (linear by default) between neighboring samples. Multiple time samples can be authored efficiently and sparsely, with USD automatically handling interpolation and temporal queries. Animation splines are the alternative for floating-point attributes, describing motion as a curve through knots instead of a dense list of samples; where both are authored at the same site, time samples win.
 
-    **Further Reading**: [Time Codes and Time Samples](<./stage-setting/timecodes-timesamples.md>), [TimeSample -- OpenUSD.org](<inv:usd:std#glossary:timesample>)
+    **Further Reading**: [Time Codes and Time Samples](<./stage-setting/timecodes-timesamples.md>), [Spline Animation](<./beyond-basics/spline-animation.md>), [TimeSample -- OpenUSD.org](<inv:usd:std#glossary:timesample>)
 
 Value Clips
 
@@ -664,7 +664,7 @@ Value Resolution
 
     Value resolution is the process of determining the final composed value for a property or metadata from all contributing opinions.
 
-    When querying attributes, USD traverses the composition index in strength order to find the strongest opinion, evaluating defaults, time samples, splines, blocks, and connections according to LIVERPS. Value resolution also handles interpolation for animated values and applies layer offsets from composition arcs. USD also has unique algorithms for resolving relationships and metadata values.
+    When querying attributes, USD traverses the composition index in LIVERPS strength order to find the strongest opinion, also accounting for blocks and connections. LIVERPS orders the contributing sites; at a single site, USD consults time samples, then animation splines, then the default value, then value clips, using the first that has a value for the requested time code. Value resolution also handles interpolation for animated values and applies layer offsets from composition arcs. USD also has unique algorithms for resolving relationships and metadata values.
 
     **Further Reading**: [What Is Value Resolution?](<./beyond-basics/value-resolution.md>), [Spline Animation](<./beyond-basics/spline-animation.md>), [Value Resolution -- OpenUSD.org](<inv:usd:std#glossary:value resolution>)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,17 @@ Animated Value
     Attributes can store time-varying data using time samples (discrete time-value pairs) or animation splines, and USD automatically interpolates between these data points when you query an attribute at a specific time. An attribute can have both a static default value and animated values, with the animated values taking precedence when querying at specific time codes.
 
     **Also Known As:** *time-varying value, time-sampled value*  
-    **Further Reading**: [Time Codes and Time Samples](<./stage-setting/timecodes-timesamples.md>), [Spline animation](<./beyond-basics/spline-animation.md>), [Animated Value -- OpenUSD.org](<inv:usd:std#glossary:animated value>)
+    **Further Reading**: [Time Codes and Time Samples](<./stage-setting/timecodes-timesamples.md>), [Spline Animation](<./beyond-basics/spline-animation.md>), [Animated Value -- OpenUSD.org](<inv:usd:std#glossary:animated value>)
+
+
+Animation Spline
+
+    An animation spline is curve-based animation authored directly on an attribute, defined by knots rather than by a dense list of time samples.
+
+    Each knot pairs a time with a value and carries tangent data and an interpolation mode for the segment that follows it, so a spline can describe smooth motion from very few keys. Splines also support inner loops (repeating a prototype segment with an optional value offset) and extrapolation beyond the authored knot range (held, linear, or looping). An attribute resolves splines alongside its default value, time samples, and value clips during value resolution, and splines are retimed by layer offsets just like time samples.
+
+    **Also Known As:** *spline, curve animation*  
+    **Further Reading**: [Spline Animation](<./beyond-basics/spline-animation.md>), [Spline -- OpenUSD.org](<inv:usd:std#glossary:spline>), [Using Splines -- OpenUSD.org](<inv:usd:std#user_guides/time_and_animated_values:using splines>)
 
 
 API Schema
@@ -656,7 +666,7 @@ Value Resolution
 
     When querying attributes, USD traverses the composition index in strength order to find the strongest opinion, evaluating defaults, time samples, splines, blocks, and connections according to LIVERPS. Value resolution also handles interpolation for animated values and applies layer offsets from composition arcs. USD also has unique algorithms for resolving relationships and metadata values.
 
-    **Further Reading**: [What Is Value Resolution?](<./beyond-basics/value-resolution.md>), [Spline animation](<./beyond-basics/spline-animation.md>), [Value Resolution -- OpenUSD.org](<inv:usd:std#glossary:value resolution>)
+    **Further Reading**: [What Is Value Resolution?](<./beyond-basics/value-resolution.md>), [Spline Animation](<./beyond-basics/spline-animation.md>), [Value Resolution -- OpenUSD.org](<inv:usd:std#glossary:value resolution>)
 
 Variability
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,7 @@ Animated Value
     Attributes can store time-varying data using time samples (discrete time-value pairs) or animation splines, and USD automatically interpolates between these data points when you query an attribute at a specific time. An attribute can have both a static default value and animated values, with the animated values taking precedence when querying at specific time codes.
 
     **Also Known As:** *time-varying value, time-sampled value*  
-    **Further Reading**: [Time Codes and Time Samples](<./stage-setting/timecodes-timesamples.md>), [Animated Value -- OpenUSD.org](<inv:usd:std#glossary:animated value>)
+    **Further Reading**: [Time Codes and Time Samples](<./stage-setting/timecodes-timesamples.md>), [Spline animation](<./beyond-basics/spline-animation.md>), [Animated Value -- OpenUSD.org](<inv:usd:std#glossary:animated value>)
 
 
 API Schema
@@ -656,7 +656,7 @@ Value Resolution
 
     When querying attributes, USD traverses the composition index in strength order to find the strongest opinion, evaluating defaults, time samples, splines, blocks, and connections according to LIVERPS. Value resolution also handles interpolation for animated values and applies layer offsets from composition arcs. USD also has unique algorithms for resolving relationships and metadata values.
 
-    **Further Reading**: [What Is Value Resolution?](<./beyond-basics/value-resolution.md>), [Value Resolution -- OpenUSD.org](<inv:usd:std#glossary:value resolution>)
+    **Further Reading**: [What Is Value Resolution?](<./beyond-basics/value-resolution.md>), [Spline animation](<./beyond-basics/spline-animation.md>), [Value Resolution -- OpenUSD.org](<inv:usd:std#glossary:value resolution>)
 
 Variability
 

--- a/src/lousd/utils/visualization.py
+++ b/src/lousd/utils/visualization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lousd/utils/visualization.py
+++ b/src/lousd/utils/visualization.py
@@ -18,6 +18,7 @@
 import html
 import logging
 import os
+from pathlib import Path
 from string import Template
 import subprocess
 from typing import Any, List, Optional, Union
@@ -225,6 +226,92 @@ def FlattenFile(input_file_path: str, show_usd_lights: bool = False) -> str:
     return destination_file_path
 
 
+def display_bake_usd_path(usd_filename: str) -> str:
+    """Return a sibling path used for spline-baked USD (preview-only)."""
+    path = Path(usd_filename)
+    return str(path.with_name(f"{path.stem}_display_bake{path.suffix}"))
+
+
+def bake_spline_attributes_to_time_samples(
+    src_path: str,
+    dst_path: str,
+    *,
+    time_step: int = 1,
+) -> None:
+    """
+    Flatten the composed stage at ``src_path`` and replace each animation spline on an attribute
+    with dense time samples evaluated from the spline. Used so ``usd2gltf`` / ``model-viewer`` can
+    playback motion (those tools key off ``UsdGeom.Xformable.GetTimeSamples()``).
+
+    The file at ``src_path`` is not modified; results are written to ``dst_path``.
+
+    Parameters:
+        src_path: USD scene to open (with composition).
+        dst_path: Output USD path for the flattened, baked scene.
+        time_step: Frame step between samples (inclusive of start/end time codes).
+    """
+    if time_step < 1:
+        raise ValueError("time_step must be >= 1")
+
+    src_stage = Usd.Stage.Open(src_path, Usd.Stage.LoadAll)
+    if not src_stage:
+        log.warning('bake_spline_attributes_to_time_samples: could not open stage at "%s".', src_path)
+        return
+
+    if src_stage.HasAuthoredTimeCodeRange():
+        start_tc = int(src_stage.GetStartTimeCode())
+        end_tc = int(src_stage.GetEndTimeCode())
+    else:
+        start_tc, end_tc = 0, 0
+
+    if end_tc < start_tc:
+        start_tc, end_tc = end_tc, start_tc
+
+    flat_layer = src_stage.Flatten()
+    flat_layer.Export(dst_path)
+
+    bake_stage = Usd.Stage.Open(dst_path, Usd.Stage.LoadAll)
+    if not bake_stage:
+        log.warning('bake_spline_attributes_to_time_samples: could not open baked stage at "%s".', dst_path)
+        return
+
+    if src_stage.HasAuthoredTimeCodeRange():
+        bake_stage.SetStartTimeCode(src_stage.GetStartTimeCode())
+        bake_stage.SetEndTimeCode(src_stage.GetEndTimeCode())
+
+    tcps = src_stage.GetTimeCodesPerSecond()
+    if tcps > 0.0:
+        bake_stage.SetTimeCodesPerSecond(tcps)
+
+    spline_attrs: List[tuple] = []
+    for prim in bake_stage.Traverse():
+        for attr in prim.GetAttributes():
+            if attr.HasSpline():
+                spline_attrs.append((prim.GetPath(), attr.GetName()))
+
+    for prim_path, attr_name in spline_attrs:
+        attr = bake_stage.GetPrimAtPath(prim_path).GetAttribute(attr_name)
+        if not attr.IsValid():
+            continue
+        sampled = {}
+        t = start_tc
+        while t <= end_tc:
+            tc = Usd.TimeCode(t)
+            sampled[t] = attr.Get(tc)
+            t += time_step
+
+        attr.Clear()
+        for frame, value in sampled.items():
+            attr.Set(value, Usd.TimeCode(frame))
+
+    bake_stage.GetRootLayer().Save()
+    log.debug(
+        'bake_spline_attributes_to_time_samples: wrote "%s" (%d spline attributes baked).',
+        dst_path,
+        len(spline_attrs),
+    )
+
+
 def CovertFile(usd_filename):
     input_file_path = usd_filename
     flattened_file_path = FlattenFile(usd_filename)
@@ -248,6 +335,7 @@ def DisplaySingleUSD(
     disable_scrollwheel_zoom: bool = True,
     show_usd_code: bool = False,
     show_usd_lights: bool = False,
+    bake_splines_for_display: bool = False,
 ) -> DisplayHandle:
     """
     Present an interactive 3D visualization in the Jupyter Notebook of the given USD file located in the `./content` folder.
@@ -260,6 +348,10 @@ def DisplaySingleUSD(
         show_usd_code (bool): Flag indicating whether to display the USDA code of the given filename in a
             syntax-highlighted panel next to its 3D visualization.
         show_usd_lights (bool): Flag indicating whether to handle USD lights during the conversion process.
+        bake_splines_for_display (bool): If True, flatten the scene and convert animation splines on attributes into
+            dense time samples in a sibling ``*_display_bake.*`` file used only for GLB conversion. The USDA panel still
+            reflects ``usd_filename`` when ``show_usd_code`` is True. This improves motion in ``model-viewer``, which
+            relies on time-sample-based export from ``usd2gltf``.
 
     Returns:
         DisplayHandle: An interactive 3D visualization of the given USD file.
@@ -268,7 +360,19 @@ def DisplaySingleUSD(
     # Unique identifier for the visualization features:
     unique_viewer_id = str(uuid4())
 
-    new_usd_filename = CovertFile(usd_filename)
+    glb_source_usd = usd_filename
+    if bake_splines_for_display:
+        baked_path = display_bake_usd_path(usd_filename)
+        bake_spline_attributes_to_time_samples(usd_filename, baked_path)
+        if os.path.isfile(baked_path):
+            glb_source_usd = baked_path
+        else:
+            log.warning(
+                'Spline bake did not produce "%s"; using original USD for GLB conversion.',
+                baked_path,
+            )
+
+    new_usd_filename = CovertFile(glb_source_usd)
 
     log.debug(msg=f'Displaying single USD file "{usd_filename}", with width={width},height={height},disable_scrollwheel_zoom={disable_scrollwheel_zoom},unique_viewer_id="{unique_viewer_id},show_usd_code={show_usd_code},show_usd_lights={show_usd_lights}".')
 
@@ -457,6 +561,7 @@ def DisplayUSD(
     disable_scrollwheel_zoom: bool = True,
     show_usd_code: bool = False,
     show_usd_lights: bool = False,
+    bake_splines_for_display: bool = False,
 ) -> DisplayHandle:
     """
     Present an interactive 3D visualization in the Jupyter Notebook of the given USD files located in the `./content` folder.
@@ -469,6 +574,7 @@ def DisplayUSD(
         show_usd_code (bool): Flag indicating whether to display the USDA code of the given filename in a
             syntax-highlighted panel next to its 3D visualization.
         show_usd_lights (bool): Flag indicating whether to handle USD lights during the conversion process.
+        bake_splines_for_display (bool): When ``usd_filenames`` is a single path, forwarded to `DisplaySingleUSD`.
 
     Returns:
         DisplayHandle: An interactive 3D visualization of the given USD file.
@@ -483,6 +589,7 @@ def DisplayUSD(
             disable_scrollwheel_zoom=disable_scrollwheel_zoom,
             show_usd_code=show_usd_code,
             show_usd_lights=show_usd_lights,
+            bake_splines_for_display=bake_splines_for_display,
         )
 
     log.debug(msg=f'Displaying multiple USD files {usd_filenames}, with width={width},height={height},disable_scrollwheel_zoom={disable_scrollwheel_zoom}.')

--- a/src/lousd/utils/visualization.py
+++ b/src/lousd/utils/visualization.py
@@ -226,44 +226,62 @@ def FlattenFile(input_file_path: str, show_usd_lights: bool = False) -> str:
     return destination_file_path
 
 
-def display_bake_usd_path(usd_filename: str) -> str:
-    """Return a sibling path used for spline-baked USD (preview-only)."""
+def DisplayBakeUSDPath(usd_filename: str) -> str:
+    """Return a sibling path used for spline-baked USD (preview-only).
+
+    Args:
+        usd_filename (str): Path of the spline-authored USD file.
+
+    Returns:
+        str: Sibling path with a ``_display_bake`` suffix on the file stem.
+    """
     path = Path(usd_filename)
     return str(path.with_name(f"{path.stem}_display_bake{path.suffix}"))
 
 
-def bake_spline_attributes_to_time_samples(
+def BakeSplineAttributesToTimeSamples(
     src_path: str,
     dst_path: str,
     *,
     time_step: int = 1,
 ) -> None:
-    """
-    Flatten the composed stage at ``src_path`` and replace each animation spline on an attribute
-    with dense time samples evaluated from the spline. Used so ``usd2gltf`` / ``model-viewer`` can
-    playback motion (those tools key off ``UsdGeom.Xformable.GetTimeSamples()``).
+    """Flatten a stage and replace its animation splines with dense time samples.
 
-    The file at ``src_path`` is not modified; results are written to ``dst_path``.
+    Each animation spline authored on an attribute is evaluated across the stage's time code
+    range and rewritten as time samples, so ``usd2gltf`` / ``model-viewer`` can play back the
+    motion (those tools key off ``UsdGeom.Xformable.GetTimeSamples()``). The file at
+    ``src_path`` is not modified; results are written to ``dst_path``.
 
-    Parameters:
-        src_path: USD scene to open (with composition).
-        dst_path: Output USD path for the flattened, baked scene.
-        time_step: Frame step between samples (inclusive of start/end time codes).
+    A stage with no authored time code range has no range to bake over, so it is exported
+    flattened with its splines left intact.
+
+    Args:
+        src_path (str): USD scene to open (with composition).
+        dst_path (str): Output USD path for the flattened, baked scene.
+        time_step (int): Frame step between samples (inclusive of start/end time codes).
+
+    Raises:
+        ValueError: If `time_step` is less than 1.
     """
     if time_step < 1:
         raise ValueError("time_step must be >= 1")
 
     src_stage = Usd.Stage.Open(src_path, Usd.Stage.LoadAll)
     if not src_stage:
-        log.warning('bake_spline_attributes_to_time_samples: could not open stage at "%s".', src_path)
+        log.warning('BakeSplineAttributesToTimeSamples: could not open stage at "%s".', src_path)
         return
 
-    if src_stage.HasAuthoredTimeCodeRange():
-        start_tc = int(src_stage.GetStartTimeCode())
-        end_tc = int(src_stage.GetEndTimeCode())
-    else:
-        start_tc, end_tc = 0, 0
+    if not src_stage.HasAuthoredTimeCodeRange():
+        log.warning(
+            'BakeSplineAttributesToTimeSamples: "%s" has no authored time code range; '
+            "exporting the flattened stage with splines left intact.",
+            src_path,
+        )
+        src_stage.Flatten().Export(dst_path)
+        return
 
+    start_tc = int(src_stage.GetStartTimeCode())
+    end_tc = int(src_stage.GetEndTimeCode())
     if end_tc < start_tc:
         start_tc, end_tc = end_tc, start_tc
 
@@ -272,12 +290,11 @@ def bake_spline_attributes_to_time_samples(
 
     bake_stage = Usd.Stage.Open(dst_path, Usd.Stage.LoadAll)
     if not bake_stage:
-        log.warning('bake_spline_attributes_to_time_samples: could not open baked stage at "%s".', dst_path)
+        log.warning('BakeSplineAttributesToTimeSamples: could not open baked stage at "%s".', dst_path)
         return
 
-    if src_stage.HasAuthoredTimeCodeRange():
-        bake_stage.SetStartTimeCode(src_stage.GetStartTimeCode())
-        bake_stage.SetEndTimeCode(src_stage.GetEndTimeCode())
+    bake_stage.SetStartTimeCode(src_stage.GetStartTimeCode())
+    bake_stage.SetEndTimeCode(src_stage.GetEndTimeCode())
 
     tcps = src_stage.GetTimeCodesPerSecond()
     if tcps > 0.0:
@@ -306,7 +323,7 @@ def bake_spline_attributes_to_time_samples(
 
     bake_stage.GetRootLayer().Save()
     log.debug(
-        'bake_spline_attributes_to_time_samples: wrote "%s" (%d spline attributes baked).',
+        'BakeSplineAttributesToTimeSamples: wrote "%s" (%d spline attributes baked).',
         dst_path,
         len(spline_attrs),
     )
@@ -362,8 +379,8 @@ def DisplaySingleUSD(
 
     glb_source_usd = usd_filename
     if bake_splines_for_display:
-        baked_path = display_bake_usd_path(usd_filename)
-        bake_spline_attributes_to_time_samples(usd_filename, baked_path)
+        baked_path = DisplayBakeUSDPath(usd_filename)
+        BakeSplineAttributesToTimeSamples(usd_filename, baked_path)
         if os.path.isfile(baked_path):
             glb_source_usd = baked_path
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the lousd package."""

--- a/tests/test_docs_beyond_basics.py
+++ b/tests/test_docs_beyond_basics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_docs_beyond_basics.py
+++ b/tests/test_docs_beyond_basics.py
@@ -44,6 +44,9 @@ CUSTOM_PROPERTIES_SETUP = ["custom-properties-setup"]
 ACTIVE_INACTIVE_NOTEBOOK = "beyond-basics/active-inactive-prims.ipynb"
 ACTIVE_INACTIVE_SETUP = ["active-inactive-setup"]
 
+SPLINE_ANIMATION_NOTEBOOK = "beyond-basics/spline-animation.ipynb"
+SPLINE_ANIMATION_SETUP = ["spline-animation-setup"]
+
 
 class TestValueResolutionNotebook:
     """Tests for beyond-basics/value-resolution.ipynb."""
@@ -280,3 +283,42 @@ class TestActiveInactivePrimsNotebook:
         # Traverse should not include /World/Box and its descendants
         traversed_paths = [p.GetPath() for p in nb.stage.Traverse()]
         assert "/World/Box" not in traversed_paths
+
+
+class TestSplineAnimationNotebook:
+    """Tests for beyond-basics/spline-animation.ipynb."""
+
+    def test_full_notebook(self, run_notebook):
+        nb = run_notebook(SPLINE_ANIMATION_NOTEBOOK)
+        assert (nb._work_dir / "_assets" / "spline_layer_offset_scene.usda").exists()
+
+    def test_cell_inner_loop(self, run_notebook):
+        nb = run_notebook(
+            SPLINE_ANIMATION_NOTEBOOK,
+            tags=SPLINE_ANIMATION_SETUP + ["spline-animation-inner-loop"],
+        )
+        assert nb.stage is not None
+        yaw = nb.stage.GetPrimAtPath("/World/RotatingCube").GetAttribute("xformOp:rotateZ:yaw")
+        assert yaw.IsValid() and yaw.HasSpline()
+        assert (nb._work_dir / "_assets" / "spline_inner_loop.usda").exists()
+
+    def test_cell_extrapolation(self, run_notebook):
+        nb = run_notebook(
+            SPLINE_ANIMATION_NOTEBOOK,
+            tags=SPLINE_ANIMATION_SETUP + ["spline-animation-extrapolation"],
+        )
+        assert nb.stage is not None
+        rock = nb.stage.GetPrimAtPath("/World/RockingCube").GetAttribute("xformOp:rotateY:rock")
+        assert rock.IsValid() and rock.HasSpline()
+        assert (nb._work_dir / "_assets" / "spline_extrapolation.usda").exists()
+
+    def test_cell_layer_offset(self, run_notebook):
+        nb = run_notebook(
+            SPLINE_ANIMATION_NOTEBOOK,
+            tags=SPLINE_ANIMATION_SETUP + ["spline-animation-layer-offset"],
+        )
+        assert nb.rig_stage is not None
+        assert nb.scene is not None
+        assert nb.early.IsValid() and nb.late.IsValid()
+        assert (nb._work_dir / "_assets" / "spline_slide_rig.usda").exists()
+        assert (nb._work_dir / "_assets" / "spline_layer_offset_scene.usda").exists()

--- a/tests/test_spline_display_bake.py
+++ b/tests/test_spline_display_bake.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific governing permissions and
+# limitations under the License.
+
+"""Tests for spline-to-time-sample baking used by DisplayUSD previews."""
+
+import os
+import tempfile
+
+import pytest
+from pxr import Ts, Usd, UsdGeom
+
+from lousd.utils.visualization import bake_spline_attributes_to_time_samples, display_bake_usd_path
+
+
+@pytest.fixture()
+def spline_usd_path():
+    tmp = tempfile.mkdtemp()
+    path = os.path.join(tmp, "rot_spline.usda")
+    stage = Usd.Stage.CreateNew(path)
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+    stage.SetTimeCodesPerSecond(24)
+    stage.SetStartTimeCode(0)
+    stage.SetEndTimeCode(10)
+
+    xf = UsdGeom.Xform.Define(stage, "/X")
+    UsdGeom.Cube.Define(stage, "/X/Cube")
+    op = xf.AddRotateZOp(opSuffix="spin")
+    attr = op.GetAttr()
+    tn = str(attr.GetTypeName())
+    spline = Ts.Spline(tn)
+    spline.SetKnot(Ts.Knot(typeName=tn, time=0, value=0, nextInterp=Ts.InterpLinear))
+    spline.SetKnot(Ts.Knot(typeName=tn, time=10, value=45, nextInterp=Ts.InterpLinear))
+    attr.SetSpline(spline)
+    stage.Save()
+    yield path
+
+
+def test_display_bake_usd_path_suffix():
+    assert display_bake_usd_path("_assets/foo.usda").endswith("_display_bake.usda")
+
+
+def test_bake_replaces_spline_with_time_samples(spline_usd_path: str):
+    tmp = os.path.dirname(spline_usd_path)
+    out = os.path.join(tmp, "out.usda")
+    bake_spline_attributes_to_time_samples(spline_usd_path, out)
+
+    baked = Usd.Stage.Open(out)
+    attr = baked.GetPrimAtPath("/X").GetAttribute("xformOp:rotateZ:spin")
+    assert attr.IsValid()
+    assert not attr.HasSpline()
+    assert attr.GetNumTimeSamples() == 11
+    xformable = UsdGeom.Xformable(baked.GetPrimAtPath("/X"))
+    assert len(xformable.GetTimeSamples()) >= 1
+
+
+def test_bake_value_spline_usd_path_not_modified(spline_usd_path: str):
+    before = open(spline_usd_path, encoding="utf-8").read()
+    out = os.path.join(os.path.dirname(spline_usd_path), "out.usda")
+    bake_spline_attributes_to_time_samples(spline_usd_path, out)
+    after = open(spline_usd_path, encoding="utf-8").read()
+    assert before == after

--- a/tests/test_spline_display_bake.py
+++ b/tests/test_spline_display_bake.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,7 +10,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific governing permissions and
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 """Tests for spline-to-time-sample baking used by DisplayUSD previews."""

--- a/tests/test_spline_display_bake.py
+++ b/tests/test_spline_display_bake.py
@@ -21,7 +21,7 @@ import tempfile
 import pytest
 from pxr import Ts, Usd, UsdGeom
 
-from lousd.utils.visualization import bake_spline_attributes_to_time_samples, display_bake_usd_path
+from lousd.utils.visualization import BakeSplineAttributesToTimeSamples, DisplayBakeUSDPath
 
 
 @pytest.fixture()
@@ -48,13 +48,13 @@ def spline_usd_path():
 
 
 def test_display_bake_usd_path_suffix():
-    assert display_bake_usd_path("_assets/foo.usda").endswith("_display_bake.usda")
+    assert DisplayBakeUSDPath("_assets/foo.usda").endswith("_display_bake.usda")
 
 
 def test_bake_replaces_spline_with_time_samples(spline_usd_path: str):
     tmp = os.path.dirname(spline_usd_path)
     out = os.path.join(tmp, "out.usda")
-    bake_spline_attributes_to_time_samples(spline_usd_path, out)
+    BakeSplineAttributesToTimeSamples(spline_usd_path, out)
 
     baked = Usd.Stage.Open(out)
     attr = baked.GetPrimAtPath("/X").GetAttribute("xformOp:rotateZ:spin")
@@ -65,9 +65,30 @@ def test_bake_replaces_spline_with_time_samples(spline_usd_path: str):
     assert len(xformable.GetTimeSamples()) >= 1
 
 
+def test_bake_without_time_code_range_preserves_spline(tmp_path):
+    src = str(tmp_path / "no_range.usda")
+    stage = Usd.Stage.CreateNew(src)
+    xf = UsdGeom.Xform.Define(stage, "/X")
+    attr = xf.AddRotateZOp(opSuffix="spin").GetAttr()
+    tn = str(attr.GetTypeName())
+    spline = Ts.Spline(tn)
+    spline.SetKnot(Ts.Knot(typeName=tn, time=0, value=0, nextInterp=Ts.InterpLinear))
+    spline.SetKnot(Ts.Knot(typeName=tn, time=10, value=45, nextInterp=Ts.InterpLinear))
+    attr.SetSpline(spline)
+    stage.Save()
+
+    out = str(tmp_path / "no_range_out.usda")
+    BakeSplineAttributesToTimeSamples(src, out)
+
+    baked = Usd.Stage.Open(out)
+    baked_attr = baked.GetPrimAtPath("/X").GetAttribute("xformOp:rotateZ:spin")
+    assert baked_attr.HasSpline()
+    assert baked_attr.GetNumTimeSamples() == 0
+
+
 def test_bake_value_spline_usd_path_not_modified(spline_usd_path: str):
     before = open(spline_usd_path, encoding="utf-8").read()
     out = os.path.join(os.path.dirname(spline_usd_path), "out.usda")
-    bake_spline_attributes_to_time_samples(spline_usd_path, out)
+    BakeSplineAttributesToTimeSamples(spline_usd_path, out)
     after = open(spline_usd_path, encoding="utf-8").read()
     assert before == after

--- a/tests/test_workshop_prep.py
+++ b/tests/test_workshop_prep.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the lousd.workshop_prep module.
 
 This module tests the workshop preparation script's functionality, including:


### PR DESCRIPTION
Adds a Spline Animation unit to *Beyond the Basics* and updates *Value Resolution* to cover splines.

Closes #8.

This supersedes #76. The original work is by @Maalvi14, whose commit is preserved with authorship intact; a second commit applies review fixes. #76's branch lives on a fork that maintainers can't push to (`maintainerCanModify: false`), so the branch was re-pushed here.

## Contents

- New `docs/beyond-basics/spline-animation.md` lesson with three runnable examples: inner loops, post extrapolation, and layer offsets applied to spline-driven motion.
- `docs/beyond-basics/value-resolution.md` now covers splines as an attribute value source, replacing the "we'll update this lesson soon" note.
- New `Animation Spline` glossary entry, plus a node for it in the interactive glossary graph.
- `DisplayUSD(..., bake_splines_for_display=True)` evaluates splines into dense time samples for preview only, so the embedded 3D viewers (which key off time samples via `usd2gltf`) can play back spline motion. Saved `_assets/*.usda` files stay spline-authored.

## Review fixes applied on top of the original commit

- Example 2 described a rocking cube but used `Ts.ExtrapLoopRepeat`, which offsets each cycle by the knot value delta and turned the cube continuously in one direction. Now uses `Ts.ExtrapLoopOscillate`, with the difference between the two modes explained.
- Query times and float formatting adjusted so the built page no longer prints `-5.329070518200751e-15`.
- Lesson restructured with `What Is Spline Animation?` / `How Does It Work?` sections and Title Case headings, matching the other Beyond the Basics lessons.
- LaTeX `\(t - 24\)` replaced with inline code — `dollarmath` isn't enabled in `docs/conf.py`, so it rendered as literal parentheses.
- Bake helpers renamed to PascalCase to match the rest of `visualization.py`, docstrings converted to Google style, and a stage with no authored time code range now exports flattened with splines intact instead of clearing the spline and writing a single sample at `t=0`.

## Testing

- `uv run sphinx-build -M html docs/ docs/_build/` — succeeds, 163 warnings, unchanged from the pre-change baseline (all pre-existing doxylink noise).
- `uv run pytest` — 128 passed, including new coverage in `tests/test_docs_beyond_basics.py` and `tests/test_spline_display_bake.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
