### PR TITLE
Fix incorrect reference asset paths in units lesson

### DIFF
--- a/docs/beyond-basics/units.md
+++ b/docs/beyond-basics/units.md
@@ -322,7 +322,7 @@ xform_api = UsdGeom.XformCommonAPI(local_anim)
 xform_api.SetTranslate(Gf.Vec3d(-5, 2, 0), Usd.TimeCode(0))
 xform_api.SetTranslate(Gf.Vec3d(5, 2, 0), Usd.TimeCode(48))
 
-# Reference thte 60fps animated sphere
+# Reference the 60fps animated sphere
 ref_prim = scene_stage.DefinePrim("/World/ReferencedAnimation")
 ref_prim.GetReferences().AddReference("./" + os.path.basename(anim_asset_path))
 

--- a/docs/beyond-basics/units.md
+++ b/docs/beyond-basics/units.md
@@ -172,7 +172,9 @@ Both cubes represent the same real-world size—1 meter. If USD automatically co
 
 ```{code-cell}
 :test-tags: [units-meters-per-unit]
-:emphasize-lines: 7,10-11,25,28-29,50-51,54-55
+:emphasize-lines: 9,12-13,27,30-31,52-53,56-57
+import os
+
 from pxr import Usd, UsdGeom, Sdf, Gf
 
 # Create a cube asset in CENTIMETERS (metersPerUnit = 0.01)
@@ -222,11 +224,11 @@ world = UsdGeom.Xform.Define(scene_stage, "/World")
 scene_stage.SetDefaultPrim(world.GetPrim())
 
 meter_ref = scene_stage.DefinePrim("/World/Cube_1m_In_Centimeters")
-meter_ref.GetReferences().AddReference(cm_asset_path)
+meter_ref.GetReferences().AddReference("./" + os.path.basename(cm_asset_path))
 UsdGeom.XformCommonAPI(meter_ref).SetTranslate(Gf.Vec3d(-1000, 0, 0))
 
 cm_ref = scene_stage.DefinePrim("/World/Cube_1m_In_Millimeters")
-cm_ref.GetReferences().AddReference(mm_asset_path)
+cm_ref.GetReferences().AddReference("./" + os.path.basename(mm_asset_path))
 UsdGeom.XformCommonAPI(cm_ref).SetTranslate(Gf.Vec3d(1000, 0, 0)) 
 
 scene_stage.Save()
@@ -261,7 +263,9 @@ This example demonstrates that USD **does** automatically handle `timeCodesPerSe
 
 ```{code-cell}
 :test-tags: [units-timecodes-per-second]
-:emphasize-lines: 8-10, 17-20, 25-27, 34-36, 52-55, 57-59, 63-67
+:emphasize-lines: 10-12, 19-22, 27-29, 36-38, 54-57, 59-61, 65-69
+import os
+
 from pxr import Usd, UsdGeom, Gf
 
 # Create animated asset at 60 fps
@@ -320,7 +324,7 @@ xform_api.SetTranslate(Gf.Vec3d(5, 2, 0), Usd.TimeCode(48))
 
 # Reference thte 60fps animated sphere
 ref_prim = scene_stage.DefinePrim("/World/ReferencedAnimation")
-ref_prim.GetReferences().AddReference(anim_asset_path)
+ref_prim.GetReferences().AddReference("./" + os.path.basename(anim_asset_path))
 
 scene_stage.Save()
 


### PR DESCRIPTION
## Summary
- The Python examples in `docs/beyond-basics/units.md` referenced sibling assets in the same `_assets` directory using their creation-time relative path (e.g. `"_assets/1m_cube_centimeters.usda"`). Since that path lacks a `./` prefix, USD's default resolver treats it as search-path relative to the process's current working directory rather than anchored to the referencing layer, so the reference only resolved by coincidence when the script's cwd happened to match.
- Updated the `AddReference(...)` calls to use `./`-anchored paths (`"./" + os.path.basename(...)`), consistent with the convention already used elsewhere in the repo (e.g. `composition-basics/references.md`), so references resolve correctly regardless of working directory.
- Updated `:emphasize-lines:` directives to match the shifted line numbers from the added `import os`.

Fixes #78

## Test plan
- [x] Extracted and ran the fixed code cells directly with `usd-core`, confirming both scenes compose correctly.
- [x] Verified the saved `.usda` files author `./`-relative references (e.g. `@./1m_cube_centimeters.usda@`) and resolve correctly when reopened from a different working directory (reproducing and confirming the fix for the reported failure).
- [x] Ran `pytest tests/test_docs_beyond_basics.py::TestUnitsNotebook::test_cell_meters_per_unit` and `::test_cell_timecodes_per_second` — both pass.